### PR TITLE
Refactor status handling

### DIFF
--- a/js/settings.js
+++ b/js/settings.js
@@ -1,3 +1,5 @@
+import { showTemporaryStatus } from './status-helper.js';
+
 export class Settings {
     constructor() {
         this.modelSelect = document.getElementById('model-select');
@@ -5,6 +7,9 @@ export class Settings {
         this.closeModalButton = document.getElementById('close-modal');
         this.saveSettingsButton = document.getElementById('save-settings');
         this.settingsButton = document.getElementById('settings-button');
+
+        // Cache the status element with the other DOM references
+        this.statusElement = document.getElementById('status');
         
         this.init();
     }
@@ -101,7 +106,7 @@ export class Settings {
         }
         
         if (!apiKey || !targetUri) {
-            this.showTemporaryStatus('Please fill in all required fields', 'error');
+            showTemporaryStatus(this.statusElement, 'Please fill in all required fields', 'error');
             return;
         }
         
@@ -115,7 +120,7 @@ export class Settings {
         }
         
         this.closeSettingsModal();
-        this.showTemporaryStatus('Settings saved', 'success');
+        showTemporaryStatus(this.statusElement, 'Settings saved', 'success');
         
         // Notify that settings have been updated
         document.dispatchEvent(new CustomEvent('settingsUpdated'));
@@ -146,29 +151,9 @@ export class Settings {
         
         if (!config.apiKey || !config.uri) {
             setTimeout(() => {
-                this.showTemporaryStatus('Please configure Azure OpenAI settings', 'info', false);
+                showTemporaryStatus(this.statusElement, 'Please configure Azure OpenAI settings', 'info', 0);
                 this.openSettingsModal();
             }, 500);
-        }
-    }
-    
-    showTemporaryStatus(message, type = 'info', autoReset = true) {
-        const statusElement = document.getElementById('status');
-        statusElement.textContent = message;
-        
-        if (type === 'error') {
-            statusElement.style.color = '#dc2626';
-        } else if (type === 'success') {
-            statusElement.style.color = '#16a34a';
-        } else {
-            statusElement.style.color = '';
-        }
-        
-        if (autoReset) {
-            setTimeout(() => {
-                statusElement.textContent = '🎙️ Click the microphone to start recording';
-                statusElement.style.color = '';
-            }, 3000);
         }
     }
 }

--- a/js/status-helper.js
+++ b/js/status-helper.js
@@ -1,0 +1,18 @@
+export function showTemporaryStatus(element, message, type = 'info', duration = 3000) {
+    element.textContent = message;
+
+    const colors = {
+        error: '#dc2626',
+        success: '#16a34a',
+        info: ''
+    };
+
+    element.style.color = colors[type] || '';
+
+    if (duration > 0) {
+        setTimeout(() => {
+            element.textContent = '🎙️ Click the microphone to start recording';
+            element.style.color = '';
+        }, duration);
+    }
+}


### PR DESCRIPTION
## Summary
- add a small helper `showTemporaryStatus` to deduplicate status logic
- use the new helper in `settings.js`

## Testing
- `node - <<'EOF'
import { showTemporaryStatus } from './js/status-helper.js';
console.log(typeof showTemporaryStatus);
EOF`
- `node - <<'EOF'
import { Settings } from './js/settings.js';
console.log(typeof Settings);
EOF`


------
https://chatgpt.com/codex/tasks/task_e_6860514ff360832eb1102d9ac69991a3