### PR TITLE
Refactor browser capability check

### DIFF
--- a/js/audio-handler.js
+++ b/js/audio-handler.js
@@ -18,7 +18,7 @@ export class AudioHandler {
         this.visualizationController = null;
         
         this.setupEventListeners();
-        this.checkBrowserSupport();
+        this.ui.checkBrowserSupport();
     }
     
     setupEventListeners() {
@@ -30,15 +30,6 @@ export class AudioHandler {
         
         // Cancel button
         this.ui.cancelButton.addEventListener('click', () => this.cancelRecording());
-    }
-    
-    checkBrowserSupport() {
-        if (!window.MediaRecorder || !navigator.mediaDevices || !navigator.mediaDevices.getUserMedia) {
-            this.ui.setStatus('Your browser does not support audio recording.');
-            this.ui.micButton.style.opacity = 0.5;
-            this.ui.micButton.style.cursor = 'not-allowed';
-            this.ui.micButton.disabled = true;
-        }
     }
     
     async toggleRecording() {

--- a/js/ui.js
+++ b/js/ui.js
@@ -1,4 +1,10 @@
 export class UI {
+    static browserSupportsRecording() {
+        return !!(window.MediaRecorder &&
+                   navigator.mediaDevices &&
+                   navigator.mediaDevices.getUserMedia);
+    }
+
     constructor() {
         // Get all DOM elements
         this.micButton = document.getElementById('mic-button');
@@ -90,13 +96,12 @@ export class UI {
     }
     
     checkBrowserSupport() {
-        // Check if browser supports required APIs
-        if (!window.MediaRecorder || !navigator.mediaDevices || !navigator.mediaDevices.getUserMedia) {
+        if (!UI.browserSupportsRecording()) {
             this.setStatus('Your browser does not support audio recording.');
-            this.micButton.style.opacity = 0.5;
-            this.micButton.style.cursor = 'not-allowed';
-            this.micButton.disabled = true;
+            this.disableMicButton();
+            return false;
         }
+        return true;
     }
     
     setupEventListeners() {


### PR DESCRIPTION
## Summary
- centralize browser capability detection in a single UI method
- remove duplicate code from `AudioHandler`
- both `AudioHandler` and `UI.init` now call the shared check

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_686054af5f9c832eafeacd042530c3b1