### PR TITLE
Centralize magic constants

### DIFF
--- a/js/api-client.js
+++ b/js/api-client.js
@@ -1,3 +1,5 @@
+import { API_PARAMS, DEFAULT_LANGUAGE } from './constants.js';
+
 export class AzureAPIClient {
     constructor(settings) {
         this.settings = settings;
@@ -11,13 +13,13 @@ export class AzureAPIClient {
         }
         
         const formData = new FormData();
-        formData.append('file', audioBlob, 'recording.webm');
-        formData.append('language', 'en');
+        formData.append(API_PARAMS.FILE, audioBlob, 'recording.webm');
+        formData.append(API_PARAMS.LANGUAGE, DEFAULT_LANGUAGE);
         
         // Add response_format for GPT-4o to avoid truncation
         if (config.model === 'gpt-4o-transcribe') {
-            formData.append('response_format', 'json');
-            formData.append('temperature', '0');
+            formData.append(API_PARAMS.RESPONSE_FORMAT, 'json');
+            formData.append(API_PARAMS.TEMPERATURE, '0');
         }
         
         try {
@@ -27,7 +29,7 @@ export class AzureAPIClient {
             
             const response = await fetch(config.uri, {
                 method: 'POST',
-                headers: { 'api-key': config.apiKey },
+                headers: { [API_PARAMS.API_KEY_HEADER]: config.apiKey },
                 body: formData
             });
             
@@ -89,11 +91,11 @@ export class AzureAPIClient {
             // Create a minimal test request (you might want to adjust this)
             const testBlob = new Blob([''], { type: 'audio/webm' });
             const formData = new FormData();
-            formData.append('file', testBlob, 'test.webm');
+            formData.append(API_PARAMS.FILE, testBlob, 'test.webm');
             
             const response = await fetch(config.uri, {
                 method: 'POST',
-                headers: { 'api-key': config.apiKey },
+                headers: { [API_PARAMS.API_KEY_HEADER]: config.apiKey },
                 body: formData
             });
             

--- a/js/audio-handler.js
+++ b/js/audio-handler.js
@@ -1,4 +1,6 @@
 // js/audio-handler.js
+import { COLORS } from './constants.js';
+
 export class AudioHandler {
     constructor(apiClient, ui, settings) {
         this.apiClient = apiClient;
@@ -238,7 +240,7 @@ export class AudioHandler {
                 
                 analyser.getByteFrequencyData(dataArray);
                 
-                canvasCtx.fillStyle = isDarkTheme ? '#0f172a' : '#f8fafc';
+                canvasCtx.fillStyle = isDarkTheme ? COLORS.DARK_BG : COLORS.LIGHT_BG;
                 canvasCtx.fillRect(0, 0, canvas.width, canvas.height);
                 
                 const barWidth = (canvas.width / bufferLength) * 2.5;
@@ -288,7 +290,7 @@ export class AudioHandler {
                     }
                     
                     // Clear the canvas
-                    canvasCtx.fillStyle = isDarkTheme ? '#0f172a' : '#f8fafc';
+                    canvasCtx.fillStyle = isDarkTheme ? COLORS.DARK_BG : COLORS.LIGHT_BG;
                     canvasCtx.fillRect(0, 0, canvas.width, canvas.height);
                 }
             };

--- a/js/constants.js
+++ b/js/constants.js
@@ -1,0 +1,25 @@
+export const COLORS = {
+    ERROR: '#dc2626',
+    SUCCESS: '#16a34a',
+    DARK_BG: '#0f172a',
+    LIGHT_BG: '#f8fafc'
+};
+
+export const STORAGE_KEYS = {
+    MODEL: 'transcription_model',
+    WHISPER_URI: 'whisper_uri',
+    WHISPER_API_KEY: 'whisper_api_key',
+    GPT4O_URI: 'gpt4o_uri',
+    GPT4O_API_KEY: 'gpt4o_api_key',
+    THEME_MODE: 'themeMode'
+};
+
+export const API_PARAMS = {
+    FILE: 'file',
+    LANGUAGE: 'language',
+    RESPONSE_FORMAT: 'response_format',
+    TEMPERATURE: 'temperature',
+    API_KEY_HEADER: 'api-key'
+};
+
+export const DEFAULT_LANGUAGE = 'en';

--- a/js/settings.js
+++ b/js/settings.js
@@ -1,4 +1,5 @@
 import { showTemporaryStatus } from './status-helper.js';
+import { STORAGE_KEYS } from './constants.js';
 
 export class Settings {
     constructor() {
@@ -22,14 +23,14 @@ export class Settings {
     }
     
     loadSavedModel() {
-        const savedModel = localStorage.getItem('transcription_model') || 'whisper';
+        const savedModel = localStorage.getItem(STORAGE_KEYS.MODEL) || 'whisper';
         this.modelSelect.value = savedModel;
     }
     
     setupEventListeners() {
         // Model change listener
         this.modelSelect.addEventListener('change', (e) => {
-            localStorage.setItem('transcription_model', e.target.value);
+            localStorage.setItem(STORAGE_KEYS.MODEL, e.target.value);
             console.log('Model changed to:', e.target.value);
             this.updateSettingsVisibility();
         });
@@ -82,10 +83,10 @@ export class Settings {
     
     loadSettingsToForm() {
         // Load saved settings into form fields
-        const whisperUri = localStorage.getItem('whisper_uri');
-        const whisperKey = localStorage.getItem('whisper_api_key');
-        const gpt4oUri = localStorage.getItem('gpt4o_uri');
-        const gpt4oKey = localStorage.getItem('gpt4o_api_key');
+        const whisperUri = localStorage.getItem(STORAGE_KEYS.WHISPER_URI);
+        const whisperKey = localStorage.getItem(STORAGE_KEYS.WHISPER_API_KEY);
+        const gpt4oUri = localStorage.getItem(STORAGE_KEYS.GPT4O_URI);
+        const gpt4oKey = localStorage.getItem(STORAGE_KEYS.GPT4O_API_KEY);
         
         if (whisperUri) document.getElementById('whisper-uri').value = whisperUri;
         if (whisperKey) document.getElementById('whisper-key').value = whisperKey;
@@ -112,11 +113,11 @@ export class Settings {
         
         // Save model-specific settings
         if (currentModel === 'whisper') {
-            localStorage.setItem('whisper_uri', targetUri);
-            localStorage.setItem('whisper_api_key', apiKey);
+            localStorage.setItem(STORAGE_KEYS.WHISPER_URI, targetUri);
+            localStorage.setItem(STORAGE_KEYS.WHISPER_API_KEY, apiKey);
         } else {
-            localStorage.setItem('gpt4o_uri', targetUri);
-            localStorage.setItem('gpt4o_api_key', apiKey);
+            localStorage.setItem(STORAGE_KEYS.GPT4O_URI, targetUri);
+            localStorage.setItem(STORAGE_KEYS.GPT4O_API_KEY, apiKey);
         }
         
         this.closeSettingsModal();
@@ -132,12 +133,12 @@ export class Settings {
     
     getModelConfig() {
         const model = this.getCurrentModel();
-        const apiKey = model === 'whisper' ? 
-            localStorage.getItem('whisper_api_key') : 
-            localStorage.getItem('gpt4o_api_key');
-        const uri = model === 'whisper' ? 
-            localStorage.getItem('whisper_uri') : 
-            localStorage.getItem('gpt4o_uri');
+        const apiKey = model === 'whisper' ?
+            localStorage.getItem(STORAGE_KEYS.WHISPER_API_KEY) :
+            localStorage.getItem(STORAGE_KEYS.GPT4O_API_KEY);
+        const uri = model === 'whisper' ?
+            localStorage.getItem(STORAGE_KEYS.WHISPER_URI) :
+            localStorage.getItem(STORAGE_KEYS.GPT4O_URI);
             
         return {
             model,

--- a/js/status-helper.js
+++ b/js/status-helper.js
@@ -1,9 +1,11 @@
+import { COLORS } from './constants.js';
+
 export function showTemporaryStatus(element, message, type = 'info', duration = 3000) {
     element.textContent = message;
 
     const colors = {
-        error: '#dc2626',
-        success: '#16a34a',
+        error: COLORS.ERROR,
+        success: COLORS.SUCCESS,
         info: ''
     };
 

--- a/js/ui.js
+++ b/js/ui.js
@@ -1,3 +1,5 @@
+import { STORAGE_KEYS, COLORS } from './constants.js';
+
 export class UI {
     static browserSupportsRecording() {
         return !!(window.MediaRecorder &&
@@ -47,7 +49,7 @@ export class UI {
     }
     
     loadTheme() {
-        const themeMode = localStorage.getItem('themeMode') || 'auto';
+        const themeMode = localStorage.getItem(STORAGE_KEYS.THEME_MODE) || 'auto';
         const themeSelect = document.getElementById('theme-mode');
         if (themeSelect) themeSelect.value = themeMode;
         
@@ -56,7 +58,7 @@ export class UI {
         // Listen for system theme changes
         if (window.matchMedia) {
             window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', () => {
-                if (localStorage.getItem('themeMode') === 'auto') {
+                if (localStorage.getItem(STORAGE_KEYS.THEME_MODE) === 'auto') {
                     this.applyTheme();
                 }
             });
@@ -64,7 +66,7 @@ export class UI {
     }
 
     applyTheme() {
-        const themeMode = localStorage.getItem('themeMode') || 'auto';
+        const themeMode = localStorage.getItem(STORAGE_KEYS.THEME_MODE) || 'auto';
         let isDark = false;
         
         if (themeMode === 'dark') {
@@ -89,7 +91,7 @@ export class UI {
         if (this.visualizer) {
             const canvasCtx = this.visualizer.getContext('2d');
             if (canvasCtx) {
-                canvasCtx.fillStyle = isDark ? '#0f172a' : '#f8fafc';
+                canvasCtx.fillStyle = isDark ? COLORS.DARK_BG : COLORS.LIGHT_BG;
                 canvasCtx.fillRect(0, 0, this.visualizer.width, this.visualizer.height);
             }
         }
@@ -108,7 +110,7 @@ export class UI {
         // Theme toggle
         if (this.themeToggle) {
             this.themeToggle.addEventListener('click', () => {
-                const currentMode = localStorage.getItem('themeMode') || 'auto';
+                const currentMode = localStorage.getItem(STORAGE_KEYS.THEME_MODE) || 'auto';
                 let newMode;
                 
                 if (currentMode === 'auto') {
@@ -119,7 +121,7 @@ export class UI {
                     newMode = 'light';
                 }
                 
-                localStorage.setItem('themeMode', newMode);
+                localStorage.setItem(STORAGE_KEYS.THEME_MODE, newMode);
                 const themeSelect = document.getElementById('theme-mode');
                 if (themeSelect) themeSelect.value = newMode;
                 this.applyTheme();
@@ -130,7 +132,7 @@ export class UI {
         const themeSelect = document.getElementById('theme-mode');
         if (themeSelect) {
             themeSelect.addEventListener('change', (e) => {
-                localStorage.setItem('themeMode', e.target.value);
+                localStorage.setItem(STORAGE_KEYS.THEME_MODE, e.target.value);
                 this.applyTheme();
             });
         }
@@ -186,9 +188,9 @@ export class UI {
         this.statusElement.textContent = message;
         
         if (type === 'error') {
-            this.statusElement.style.color = '#dc2626';
+            this.statusElement.style.color = COLORS.ERROR;
         } else if (type === 'success') {
-            this.statusElement.style.color = '#16a34a';
+            this.statusElement.style.color = COLORS.SUCCESS;
         } else {
             this.statusElement.style.color = '';
         }
@@ -280,7 +282,7 @@ export class UI {
         if (this.visualizer) {
             const canvasCtx = this.visualizer.getContext('2d');
             const isDarkTheme = document.body.classList.contains('dark-theme');
-            canvasCtx.fillStyle = isDarkTheme ? '#0f172a' : '#f8fafc';
+            canvasCtx.fillStyle = isDarkTheme ? COLORS.DARK_BG : COLORS.LIGHT_BG;
             canvasCtx.fillRect(0, 0, this.visualizer.width, this.visualizer.height);
         }
     }


### PR DESCRIPTION
## Summary
- add `js/constants.js` for color codes, storage keys and API parameter names
- refactor JS files to import the shared constants

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_686068b65ad4832e916e0cc36465c87a