### PR TITLE
Centralize reset status string

### DIFF
--- a/index.html
+++ b/index.html
@@ -53,7 +53,7 @@
                 <canvas id="visualizer"></canvas>
             </div>
             
-            <div id="status" class="status" aria-live="polite">Click the microphone to start recording</div>
+            <div id="status" class="status" aria-live="polite">🎙️ Click the microphone to start recording</div>
             <div id="timer" style="margin: 0.25rem 0;">00:00</div>
             
             <div class="control-buttons-container">

--- a/js/constants.js
+++ b/js/constants.js
@@ -27,3 +27,5 @@ export const API_PARAMS = {
 
 export const DEFAULT_LANGUAGE  = 'en';
 export const DEFAULT_FILENAME  = 'recording.webm';   // used when uploading audio
+export const DEFAULT_RESET_STATUS =
+  '🎙️ Click the microphone to start recording';

--- a/js/status-helper.js
+++ b/js/status-helper.js
@@ -1,11 +1,11 @@
-import { COLORS } from './constants.js';
+import { COLORS, DEFAULT_RESET_STATUS } from './constants.js';
 
 export function showTemporaryStatus(
     element,
     message,
     type = 'info',
     duration = 3000,
-    resetMessage = '🎙️ Click the microphone to start recording'
+    resetMessage = DEFAULT_RESET_STATUS
 ) {
     element.textContent = message;
 

--- a/js/ui.js
+++ b/js/ui.js
@@ -1,4 +1,4 @@
-import { STORAGE_KEYS, COLORS } from './constants.js';
+import { STORAGE_KEYS, COLORS, DEFAULT_RESET_STATUS } from './constants.js';
 import { showTemporaryStatus } from './status-helper.js';
 
 export class UI {
@@ -37,7 +37,7 @@ export class UI {
         this.audioHandler = audioHandler;
         
         // Set initial status
-        this.setStatus('🎙️ Click the microphone to start recording');
+        this.setStatus(DEFAULT_RESET_STATUS);
         
         // Load theme
         this.loadTheme();


### PR DESCRIPTION
## Summary
- define `DEFAULT_RESET_STATUS` in constants
- use `DEFAULT_RESET_STATUS` in status helper and UI
- update index.html default status text

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6861a5fc0acc832ea1e7d43a9b603a3b