### PR TITLE
Fix recording stop conditions

### DIFF
--- a/js/audio-handler.js
+++ b/js/audio-handler.js
@@ -163,13 +163,13 @@ export class AudioHandler {
     }
     
     stopRecording() {
-        if (this.mediaRecorder && this.stateMachine.canStop()) {
+        if (this.mediaRecorder && this.mediaRecorder.state !== 'inactive') {
             this.mediaRecorder.stop();
         }
     }
     
     async gracefulStop(delayMs = 800) {
-        if (!this.mediaRecorder || !this.stateMachine.canStop()) return;
+        if (!this.mediaRecorder || this.mediaRecorder.state === 'inactive') return;
         
         // 1. Keep capturing a short tail to ensure complete audio including the tail
         await new Promise(res => setTimeout(res, delayMs));


### PR DESCRIPTION
## Summary
- simplify `stopRecording()` and `gracefulStop()` guards
- ensure they run once mediaRecorder is available

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_6861cc129d58832e99b3e2d86d525ff9