### PR TITLE
Fix language parameter for translate model

### DIFF
--- a/js/api-client.js
+++ b/js/api-client.js
@@ -15,7 +15,9 @@ export class AzureAPIClient {
         
         const formData = new FormData();
         formData.append(API_PARAMS.FILE, audioBlob, DEFAULT_FILENAME);
-        formData.append(API_PARAMS.LANGUAGE, DEFAULT_LANGUAGE);
+        if (config.model !== 'whisper-translate') {
+            formData.append(API_PARAMS.LANGUAGE, DEFAULT_LANGUAGE);
+        }
         
         // Add response_format for GPT-4o to avoid truncation
         if (config.model === 'gpt-4o-transcribe') {


### PR DESCRIPTION
## Summary
- only include the language parameter for non `whisper-translate` requests

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6861e1969734832ebbc17a800a2c4871