### PR TITLE
Update stop logic using recording state machine

### DIFF
--- a/js/audio-handler.js
+++ b/js/audio-handler.js
@@ -63,7 +63,7 @@ export class AudioHandler {
     async toggleRecording() {
         if (this.stateMachine.canRecord()) {
             await this.startRecordingFlow();
-        } else if (this.stateMachine.canStop()) {
+        } else if (this.stateMachine.canInvokeStop()) {
             await this.stopRecordingFlow();
         }
     }
@@ -171,10 +171,13 @@ export class AudioHandler {
     }
 
     stopRecording() {
-        this.safeStopRecorder();
+        if (this.stateMachine.canInvokeStop()) {
+            this.safeStopRecorder();
+        }
     }
-    
+
     async gracefulStop(delayMs = 800) {
+        if (!this.stateMachine.canInvokeStop()) return;
         if (!this.mediaRecorder || this.mediaRecorder.state === 'inactive') return;
 
         // 1. Keep capturing a short tail to ensure complete audio including the tail
@@ -190,8 +193,8 @@ export class AudioHandler {
             }
         });
 
-        // 3. Stop recording if still active
-        if (this.mediaRecorder && this.mediaRecorder.state !== 'inactive') {
+        // 3. Stop recording if still active and stopping is allowed
+        if (this.stateMachine.canInvokeStop() && this.mediaRecorder && this.mediaRecorder.state !== 'inactive') {
             this.safeStopRecorder();
         }
     }

--- a/js/recording-state-machine.js
+++ b/js/recording-state-machine.js
@@ -182,6 +182,20 @@ export class RecordingStateMachine {
     canStop() {
         return [RECORDING_STATES.RECORDING, RECORDING_STATES.PAUSED].includes(this.currentState);
     }
+
+    /**
+     * Determine if the recorder can be asked to stop. This returns true when
+     * recording is active, paused or already in the process of stopping or
+     * cancelling.
+     */
+    canInvokeStop() {
+        return [
+            RECORDING_STATES.RECORDING,
+            RECORDING_STATES.PAUSED,
+            RECORDING_STATES.STOPPING,
+            RECORDING_STATES.CANCELLING
+        ].includes(this.currentState);
+    }
     
     canCancel() {
         return [RECORDING_STATES.RECORDING, RECORDING_STATES.PAUSED].includes(this.currentState);


### PR DESCRIPTION
## Summary
- add `canInvokeStop` helper to recording state machine
- use `canInvokeStop` within audio handler for stop flows
- guard stop actions with state machine checks

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68620924e780832e870180d76d277278