### PR TITLE
Improve status timeout handling

### DIFF
--- a/js/status-helper.js
+++ b/js/status-helper.js
@@ -17,10 +17,21 @@ export function showTemporaryStatus(
 
     element.style.color = colors[type] || '';
 
+    // Clear any existing timeout on the element
+    if (element._statusTimeout) {
+        clearTimeout(element._statusTimeout);
+        element._statusTimeout = null;
+    }
+
     if (duration > 0) {
-        setTimeout(() => {
-            element.textContent = resetMessage;
-            element.style.color = '';
+        const originalMessage = message;
+        element._statusTimeout = setTimeout(() => {
+            // Only reset if the message has not been changed meanwhile
+            if (element.textContent === originalMessage) {
+                element.textContent = resetMessage;
+                element.style.color = '';
+            }
+            element._statusTimeout = null;
         }, duration);
     }
 }

--- a/js/ui.js
+++ b/js/ui.js
@@ -304,6 +304,11 @@ export class UI {
     }
     
     setStatus(message) {
+        if (this.statusElement._statusTimeout) {
+            clearTimeout(this.statusElement._statusTimeout);
+            this.statusElement._statusTimeout = null;
+        }
+
         this.statusElement.textContent = message;
         this.statusElement.style.color = '';
     }

--- a/tests/status-reset.test.js
+++ b/tests/status-reset.test.js
@@ -1,0 +1,21 @@
+import { jest } from '@jest/globals';
+import { showTemporaryStatus } from '../js/status-helper.js';
+import { UI } from '../js/ui.js';
+
+
+describe('status resets', () => {
+  it('does not reset if status updated before timeout', () => {
+    jest.useFakeTimers();
+    const el = { textContent: '', style: { color: '' } };
+
+    showTemporaryStatus(el, 'temp', 'info', 1000, 'reset');
+
+    // Update status before the timeout fires
+    UI.prototype.setStatus.call({ statusElement: el }, 'new');
+
+    jest.runAllTimers();
+
+    expect(el.textContent).toBe('new');
+    jest.useRealTimers();
+  });
+});


### PR DESCRIPTION
## Summary
- clear any existing timeout before showing a temporary status
- store timeout ID on the element to allow cancellation
- reset status only if it hasn't been updated
- cancel timeout in `UI.setStatus`
- add unit test covering reset logic

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68621d99dcd0832e9916de257b78e147