### PR TITLE
Fix visualizer stop on recording stop

### DIFF
--- a/js/recording-state-machine.js
+++ b/js/recording-state-machine.js
@@ -112,6 +112,17 @@ export class RecordingStateMachine {
             message: MESSAGES.FINISHING_RECORDING,
             type: 'info'
         });
+        // Immediately reflect stopped state in the UI
+        this.audioHandler.ui.setRecordingState(false);
+
+        if (this.audioHandler.visualizationController) {
+            this.audioHandler.visualizationController.stop();
+            this.audioHandler.visualizationController = null;
+            if (this.audioHandler.ui.clearVisualization) {
+                this.audioHandler.ui.clearVisualization();
+            }
+        }
+
         // Don't disable the mic button here - let it stay clickable
         // The button will be properly managed in processing/idle states
     }

--- a/tests/visualization-stop.test.js
+++ b/tests/visualization-stop.test.js
@@ -1,0 +1,19 @@
+import { jest } from '@jest/globals';
+import { RecordingStateMachine } from '../js/recording-state-machine.js';
+import { RECORDING_STATES } from '../js/constants.js';
+
+describe('visualization stops on stopping state', () => {
+  it('stops visualization on stopping', async () => {
+    const ui = { setRecordingState: jest.fn(), clearVisualization: jest.fn() };
+    const visualizationController = { stop: jest.fn() };
+    const audioHandler = { ui, visualizationController };
+    const sm = new RecordingStateMachine(audioHandler);
+
+    sm.currentState = RECORDING_STATES.RECORDING;
+    await sm.transitionTo(RECORDING_STATES.STOPPING);
+
+    expect(ui.setRecordingState).toHaveBeenCalledWith(false);
+    expect(visualizationController.stop).toHaveBeenCalled();
+    expect(audioHandler.visualizationController).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- stop the visualization immediately when transitioning to `STOPPING`
- test that visual feedback is halted at the proper state

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686365fb13d4832ebe7de429c9beef70