### PR TITLE
Fix DOM mocks across tests

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -16,6 +16,7 @@ export default {
     }
   },
   verbose: true,
+  setupFilesAfterEnv: ['<rootDir>/tests/setupTests.js'],
   testMatch: ['**/tests/**/*.test.js'],
   testTimeout: 10000,
   moduleNameMapper: {

--- a/tests/api-client-errors.test.js
+++ b/tests/api-client-errors.test.js
@@ -7,6 +7,7 @@
 import { jest } from '@jest/globals';
 import { eventBus, APP_EVENTS } from '../js/event-bus.js';
 import { MESSAGES } from '../js/constants.js';
+import { applyDomSpies } from './setupTests.js';
 
 // Mock Settings
 const mockSettings = {
@@ -57,6 +58,7 @@ describe('AzureAPIClient Error Handling', () => {
     
     beforeEach(() => {
         jest.clearAllMocks();
+        applyDomSpies();
         
         // Setup default mock settings
         mockSettings.getModelConfig.mockReturnValue({
@@ -83,7 +85,7 @@ describe('AzureAPIClient Error Handling', () => {
     });
     
     afterEach(() => {
-        jest.restoreAllMocks();
+        jest.clearAllMocks();
     });
 
     describe('Configuration Validation Errors', () => {

--- a/tests/api-client-validation.test.js
+++ b/tests/api-client-validation.test.js
@@ -6,6 +6,7 @@
 import { jest } from '@jest/globals';
 import { eventBus, APP_EVENTS } from '../js/event-bus.js';
 import { MESSAGES } from '../js/constants.js';
+import { applyDomSpies } from './setupTests.js';
 
 // Mock Settings
 const mockSettings = {
@@ -48,6 +49,7 @@ describe('AzureAPIClient Configuration Validation', () => {
     
     beforeEach(() => {
         jest.clearAllMocks();
+        applyDomSpies();
         
         // Setup default mock settings
         mockSettings.getModelConfig.mockReturnValue({
@@ -64,7 +66,7 @@ describe('AzureAPIClient Configuration Validation', () => {
     });
     
     afterEach(() => {
-        jest.restoreAllMocks();
+        jest.clearAllMocks();
     });
 
     describe('validateConfig Method', () => {

--- a/tests/audio-handler-integration.test.js
+++ b/tests/audio-handler-integration.test.js
@@ -3,6 +3,9 @@
  * Verifies edge cases in audio handling, cleanup after errors, and timer accuracy.
  */
 
+import { jest } from '@jest/globals';
+import { applyDomSpies } from './setupTests.js';
+
 // Mock dependencies
 jest.unstable_mockModule('../js/logger.js', () => ({
   logger: {
@@ -64,6 +67,7 @@ describe('AudioHandler Integration', () => {
   
   beforeEach(() => {
     jest.clearAllMocks();
+    applyDomSpies();
     
     // Reset event handlers
     mediaRecorderEventHandlers = {
@@ -150,7 +154,7 @@ describe('AudioHandler Integration', () => {
   });
   
   afterEach(() => {
-    jest.restoreAllMocks();
+    jest.clearAllMocks();
   });
   
   describe('MediaRecorder Integration Edge Cases', () => {

--- a/tests/error-recovery.test.js
+++ b/tests/error-recovery.test.js
@@ -4,6 +4,9 @@
  * configuration issues, and state machine error states.
  */
 
+import { jest } from '@jest/globals';
+import { applyDomSpies } from './setupTests.js';
+
 // Mock dependencies
 jest.unstable_mockModule('../js/logger.js', () => ({
   logger: {
@@ -87,6 +90,7 @@ describe('Error Recovery Scenarios', () => {
   
   beforeEach(() => {
     jest.clearAllMocks();
+    applyDomSpies();
     
     // Create mock UI
     mockUI = {
@@ -137,7 +141,7 @@ describe('Error Recovery Scenarios', () => {
   });
   
   afterEach(() => {
-    jest.restoreAllMocks();
+    jest.clearAllMocks();
   });
 
   describe('Permission Denial Recovery', () => {

--- a/tests/helpers/test-dom.js
+++ b/tests/helpers/test-dom.js
@@ -1,0 +1,28 @@
+import { jest } from '@jest/globals';
+
+export function applyDomSpies() {
+  const elements = {};
+  global.document.getElementById = jest.fn(id => {
+    if (!elements[id]) {
+      elements[id] = {
+        id,
+        innerHTML: '',
+        textContent: '',
+        value: '',
+        style: { display: '' },
+        classList: {
+          add: jest.fn(),
+          remove: jest.fn(),
+          contains: jest.fn().mockReturnValue(false),
+          toggle: jest.fn()
+        },
+        addEventListener: jest.fn(),
+        removeEventListener: jest.fn(),
+        click: jest.fn(),
+        disabled: false,
+        checked: false
+      };
+    }
+    return elements[id];
+  });
+}

--- a/tests/permission-manager.test.js
+++ b/tests/permission-manager.test.js
@@ -6,6 +6,7 @@
 import { jest } from '@jest/globals';
 import { eventBus, APP_EVENTS } from '../js/event-bus.js';
 import { MESSAGES } from '../js/constants.js';
+import { applyDomSpies } from './setupTests.js';
 
 // Mock dependencies
 jest.unstable_mockModule('../js/status-helper.js', () => ({
@@ -74,6 +75,7 @@ describe('PermissionManager', () => {
     
     beforeEach(() => {
         jest.clearAllMocks();
+        applyDomSpies();
         
         // Reset mock state
         mockMediaDevices.getUserMedia.mockReset();
@@ -92,7 +94,7 @@ describe('PermissionManager', () => {
     });
     
     afterEach(() => {
-        jest.restoreAllMocks();
+        jest.clearAllMocks();
     });
     
     describe('Browser Support Detection', () => {

--- a/tests/recording-integration.test.js
+++ b/tests/recording-integration.test.js
@@ -3,6 +3,9 @@
  * Tests the full recording start → stop → transcription flow and other recording lifecycles.
  */
 
+import { jest } from '@jest/globals';
+import { applyDomSpies } from './setupTests.js';
+
 // Mock dependencies
 jest.unstable_mockModule('../js/logger.js', () => ({
   logger: {
@@ -146,6 +149,7 @@ describe('Recording Integration', () => {
   
   beforeEach(() => {
     jest.clearAllMocks();
+    applyDomSpies();
     
     // Create mock UI
     mockUI = {
@@ -199,7 +203,7 @@ describe('Recording Integration', () => {
   });
   
   afterEach(() => {
-    jest.restoreAllMocks();
+    jest.clearAllMocks();
   });
   
   describe('Full Recording Start → Stop → Transcription Flow', () => {

--- a/tests/settings-validation.test.js
+++ b/tests/settings-validation.test.js
@@ -5,6 +5,7 @@
 
 import { jest } from '@jest/globals';
 import { eventBus, APP_EVENTS } from '../js/event-bus.js';
+import { applyDomSpies } from './setupTests.js';
 
 // Mock localStorage
 const localStorageMock = {
@@ -54,6 +55,7 @@ describe('Settings Validation', () => {
 
     beforeEach(() => {
         jest.clearAllMocks();
+        applyDomSpies();
         localStorageMock.getItem.mockReturnValue(null);
         
         settings = new Settings();
@@ -70,7 +72,7 @@ describe('Settings Validation', () => {
     });
 
     afterEach(() => {
-        jest.restoreAllMocks();
+        jest.clearAllMocks();
     });
 
     describe('API Key Validation', () => {

--- a/tests/setupTests.js
+++ b/tests/setupTests.js
@@ -1,0 +1,16 @@
+import { afterEach, expect, jest } from '@jest/globals';
+import { applyDomSpies as baseApplyDomSpies } from './helpers/test-dom.js';
+
+export const applyDomSpies = baseApplyDomSpies;
+
+// Apply DOM spies once so document API is mocked for all suites
+if (global.document) {
+  applyDomSpies();
+}
+
+// Safety net to ensure DOM spies remain active
+afterEach(() => {
+  if (global.document) {
+    expect(jest.isMockFunction(global.document.getElementById)).toBe(true);
+  }
+});

--- a/tests/ui-event-bus-proper.test.js
+++ b/tests/ui-event-bus-proper.test.js
@@ -5,6 +5,7 @@
  */
 
 import { jest } from '@jest/globals';
+import { applyDomSpies } from './setupTests.js';
 
 // Mock DOM completely to prevent any real DOM access
 global.document = {
@@ -45,6 +46,7 @@ describe('UI Event Bus Communication', () => {
     let ui;
 
     beforeEach(() => {
+        applyDomSpies();
         // Create UI instance
         ui = new UI();
         
@@ -68,7 +70,7 @@ describe('UI Event Bus Communication', () => {
     });
 
     afterEach(() => {
-        jest.restoreAllMocks();
+        jest.clearAllMocks();
     });
 
     describe('Timer Events', () => {

--- a/tests/ui-event-bus.test.js
+++ b/tests/ui-event-bus.test.js
@@ -5,6 +5,7 @@
  */
 
 import { jest } from '@jest/globals';
+import { applyDomSpies } from './setupTests.js';
 import { eventBus, APP_EVENTS } from '../js/event-bus.js';
 
 // Mock showTemporaryStatus
@@ -85,6 +86,7 @@ describe('UI Event Bus Interactions', () => {
     beforeEach(() => {
         // Clear all mocks before each test
         jest.clearAllMocks();
+        applyDomSpies();
         
         // Create UI instance - this will now get proper mock elements
         ui = new UI();
@@ -97,7 +99,7 @@ describe('UI Event Bus Interactions', () => {
     });
 
     afterEach(() => {
-        jest.restoreAllMocks();
+        jest.clearAllMocks();
     });
 
     describe('Timer Control Events', () => {


### PR DESCRIPTION
## Summary
- keep DOM spies alive between test suites
- use `jest.clearAllMocks` instead of `restoreAllMocks`
- add central DOM helper and setup file
- hook setup file into Jest config

## Testing
- `npm test` *(fails: TypeError this.ui.micButton.addEventListener is not a function)*

------
https://chatgpt.com/codex/tasks/task_e_6865f5b052f0832ea71b78b61cc519ef