### PR TITLE
Ensure DOM spies persist after jest.clearAllMocks

### DIFF
--- a/tests/api-client-errors.test.js
+++ b/tests/api-client-errors.test.js
@@ -86,6 +86,7 @@ describe('AzureAPIClient Error Handling', () => {
     
     afterEach(() => {
         jest.clearAllMocks();
+        applyDomSpies();
     });
 
     describe('Configuration Validation Errors', () => {

--- a/tests/api-client-validation.test.js
+++ b/tests/api-client-validation.test.js
@@ -67,6 +67,7 @@ describe('AzureAPIClient Configuration Validation', () => {
     
     afterEach(() => {
         jest.clearAllMocks();
+        applyDomSpies();
     });
 
     describe('validateConfig Method', () => {

--- a/tests/audio-handler-integration.test.js
+++ b/tests/audio-handler-integration.test.js
@@ -155,6 +155,7 @@ describe('AudioHandler Integration', () => {
   
   afterEach(() => {
     jest.clearAllMocks();
+    applyDomSpies();
   });
   
   describe('MediaRecorder Integration Edge Cases', () => {

--- a/tests/error-recovery.test.js
+++ b/tests/error-recovery.test.js
@@ -142,6 +142,7 @@ describe('Error Recovery Scenarios', () => {
   
   afterEach(() => {
     jest.clearAllMocks();
+    applyDomSpies();
   });
 
   describe('Permission Denial Recovery', () => {

--- a/tests/permission-manager.test.js
+++ b/tests/permission-manager.test.js
@@ -95,6 +95,7 @@ describe('PermissionManager', () => {
     
     afterEach(() => {
         jest.clearAllMocks();
+        applyDomSpies();
     });
     
     describe('Browser Support Detection', () => {

--- a/tests/recording-integration.test.js
+++ b/tests/recording-integration.test.js
@@ -204,6 +204,7 @@ describe('Recording Integration', () => {
   
   afterEach(() => {
     jest.clearAllMocks();
+    applyDomSpies();
   });
   
   describe('Full Recording Start → Stop → Transcription Flow', () => {

--- a/tests/settings-validation.test.js
+++ b/tests/settings-validation.test.js
@@ -73,6 +73,7 @@ describe('Settings Validation', () => {
 
     afterEach(() => {
         jest.clearAllMocks();
+        applyDomSpies();
     });
 
     describe('API Key Validation', () => {

--- a/tests/ui-event-bus-proper.test.js
+++ b/tests/ui-event-bus-proper.test.js
@@ -71,6 +71,7 @@ describe('UI Event Bus Communication', () => {
 
     afterEach(() => {
         jest.clearAllMocks();
+        applyDomSpies();
     });
 
     describe('Timer Events', () => {

--- a/tests/ui-event-bus.test.js
+++ b/tests/ui-event-bus.test.js
@@ -100,6 +100,7 @@ describe('UI Event Bus Interactions', () => {
 
     afterEach(() => {
         jest.clearAllMocks();
+        applyDomSpies();
     });
 
     describe('Timer Control Events', () => {

--- a/tests/visualization-stop-expanded.test.js
+++ b/tests/visualization-stop-expanded.test.js
@@ -6,6 +6,7 @@
 import { jest } from '@jest/globals';
 import { eventBus, APP_EVENTS } from '../js/event-bus.js';
 import { COLORS } from '../js/constants.js';
+import { applyDomSpies } from './setupTests.js';
 
 // Mock window.requestAnimationFrame and cancelAnimationFrame
 global.requestAnimationFrame = jest.fn(cb => {
@@ -109,6 +110,7 @@ describe('Visualization Event Handling and Cleanup', () => {
   
   afterEach(() => {
     jest.clearAllMocks();
+    applyDomSpies();
   });
   
   describe('Basic Visualization Control', () => {


### PR DESCRIPTION
## Summary
- replace `restoreAllMocks` usage with `clearAllMocks` and reapply DOM spies
- import `applyDomSpies` where needed and call it after clearing mocks

## Testing
- `npm test` *(fails: cannot read properties, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_6866da80ed68832eba6909a4274b1d34