### PR TITLE
Reset event bus between test suites

### DIFF
--- a/tests/audio-handler-integration.test.js
+++ b/tests/audio-handler-integration.test.js
@@ -4,7 +4,7 @@
  */
 
 import { jest } from '@jest/globals';
-import { applyDomSpies } from './setupTests.js';
+import { applyDomSpies, resetEventBus } from './setupTests.js';
 
 // Mock dependencies
 jest.unstable_mockModule('../js/logger.js', () => ({
@@ -156,6 +156,7 @@ describe('AudioHandler Integration', () => {
   afterEach(() => {
     jest.clearAllMocks();
     applyDomSpies();
+    resetEventBus();
   });
   
   describe('MediaRecorder Integration Edge Cases', () => {

--- a/tests/audio-handler-stop.test.js
+++ b/tests/audio-handler-stop.test.js
@@ -1,6 +1,7 @@
 
 import { jest } from '@jest/globals';
 import { AudioHandler } from '../js/audio-handler.js';
+import { resetEventBus } from './setupTests.js';
 
 describe('safeStopRecorder', () => {
   it('calls stop only when active', () => {
@@ -24,5 +25,9 @@ describe('safeStopRecorder', () => {
     handler.mediaRecorder.state = 'recording';
     handler.safeStopRecorder();
     expect(handler.mediaRecorder.stop).toHaveBeenCalledTimes(1);
+  });
+
+  afterEach(() => {
+    resetEventBus();
   });
 });

--- a/tests/error-recovery.test.js
+++ b/tests/error-recovery.test.js
@@ -5,7 +5,7 @@
  */
 
 import { jest } from '@jest/globals';
-import { applyDomSpies } from './setupTests.js';
+import { applyDomSpies, resetEventBus } from './setupTests.js';
 
 // Mock dependencies
 jest.unstable_mockModule('../js/logger.js', () => ({
@@ -143,6 +143,7 @@ describe('Error Recovery Scenarios', () => {
   afterEach(() => {
     jest.clearAllMocks();
     applyDomSpies();
+    resetEventBus();
   });
 
   describe('Permission Denial Recovery', () => {

--- a/tests/recording-integration.test.js
+++ b/tests/recording-integration.test.js
@@ -4,7 +4,7 @@
  */
 
 import { jest } from '@jest/globals';
-import { applyDomSpies } from './setupTests.js';
+import { applyDomSpies, resetEventBus } from './setupTests.js';
 
 // Mock dependencies
 jest.unstable_mockModule('../js/logger.js', () => ({
@@ -205,6 +205,7 @@ describe('Recording Integration', () => {
   afterEach(() => {
     jest.clearAllMocks();
     applyDomSpies();
+    resetEventBus();
   });
   
   describe('Full Recording Start → Stop → Transcription Flow', () => {

--- a/tests/setupTests.js
+++ b/tests/setupTests.js
@@ -1,7 +1,13 @@
 import { afterEach, expect, jest } from '@jest/globals';
 import { applyDomSpies as baseApplyDomSpies } from './helpers/test-dom.js';
+import { eventBus } from '../js/event-bus.js';
 
 export const applyDomSpies = baseApplyDomSpies;
+
+export function resetEventBus() {
+  if (eventBus?.clear) eventBus.clear();
+  else eventBus.removeAllListeners?.();
+}
 
 // Apply DOM spies once so document API is mocked for all suites
 if (global.document) {
@@ -12,5 +18,10 @@ if (global.document) {
 afterEach(() => {
   if (global.document) {
     expect(jest.isMockFunction(global.document.getElementById)).toBe(true);
+  }
+  if (typeof eventBus.getEvents === 'function') {
+    expect(eventBus.getEvents().length).toBe(0);
+  } else if (eventBus.listenerCount) {
+    expect(eventBus.listenerCount()).toBe(0);
   }
 });

--- a/tests/ui-event-bus-proper.test.js
+++ b/tests/ui-event-bus-proper.test.js
@@ -5,7 +5,7 @@
  */
 
 import { jest } from '@jest/globals';
-import { applyDomSpies } from './setupTests.js';
+import { applyDomSpies, resetEventBus } from './setupTests.js';
 
 // Mock DOM completely to prevent any real DOM access
 global.document = {
@@ -72,6 +72,7 @@ describe('UI Event Bus Communication', () => {
     afterEach(() => {
         jest.clearAllMocks();
         applyDomSpies();
+        resetEventBus();
     });
 
     describe('Timer Events', () => {

--- a/tests/ui-event-bus.test.js
+++ b/tests/ui-event-bus.test.js
@@ -5,7 +5,7 @@
  */
 
 import { jest } from '@jest/globals';
-import { applyDomSpies } from './setupTests.js';
+import { applyDomSpies, resetEventBus } from './setupTests.js';
 import { eventBus, APP_EVENTS } from '../js/event-bus.js';
 
 // Mock showTemporaryStatus
@@ -87,9 +87,12 @@ describe('UI Event Bus Interactions', () => {
         // Clear all mocks before each test
         jest.clearAllMocks();
         applyDomSpies();
-        
+
         // Create UI instance - this will now get proper mock elements
         ui = new UI();
+
+        // Register event bus listeners before emitting events
+        ui.setupEventBusListeners();
         
         // The UI constructor should now work without console errors
         // since we're providing proper mock DOM elements
@@ -101,6 +104,7 @@ describe('UI Event Bus Interactions', () => {
     afterEach(() => {
         jest.clearAllMocks();
         applyDomSpies();
+        resetEventBus();
     });
 
     describe('Timer Control Events', () => {

--- a/tests/visualization-stop-expanded.test.js
+++ b/tests/visualization-stop-expanded.test.js
@@ -6,7 +6,7 @@
 import { jest } from '@jest/globals';
 import { eventBus, APP_EVENTS } from '../js/event-bus.js';
 import { COLORS } from '../js/constants.js';
-import { applyDomSpies } from './setupTests.js';
+import { applyDomSpies, resetEventBus } from './setupTests.js';
 
 // Mock window.requestAnimationFrame and cancelAnimationFrame
 global.requestAnimationFrame = jest.fn(cb => {
@@ -111,6 +111,7 @@ describe('Visualization Event Handling and Cleanup', () => {
   afterEach(() => {
     jest.clearAllMocks();
     applyDomSpies();
+    resetEventBus();
   });
   
   describe('Basic Visualization Control', () => {

--- a/tests/visualization-stop.test.js
+++ b/tests/visualization-stop.test.js
@@ -2,6 +2,7 @@
 
 import { jest } from '@jest/globals';
 import { eventBus, APP_EVENTS } from '../js/event-bus.js';
+import { resetEventBus } from './setupTests.js';
 
 // Mock VisualizationController module using ESM mocking
 const mockController = { start: jest.fn(), stop: jest.fn() };
@@ -30,6 +31,11 @@ describe('UI visualization event handling (UI is sole controller)', () => {
     mockController.start.mockClear();
     mockController.stop.mockClear();
     ui.clearVisualization.mockClear();
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+    resetEventBus();
   });
 
   it('starts visualization on VISUALIZATION_START event if stream is provided', async () => {


### PR DESCRIPTION
## Summary
- provide `resetEventBus` helper to clear listeners
- clean up event bus after tests that register listeners
- ensure `ui-event-bus.test.js` registers listeners before emitting
- verify bus is empty after each test

## Testing
- `npm test --silent` *(fails: settings.validateConfiguration is not a function)*

------
https://chatgpt.com/codex/tasks/task_e_6866e320be74832ebcbdc9abaa924e70