### PR TITLE
Add fake timers in timer-driven suites

### DIFF
--- a/tests/audio-handler-integration.test.js
+++ b/tests/audio-handler-integration.test.js
@@ -160,6 +160,14 @@ describe('AudioHandler Integration', () => {
   });
   
   describe('MediaRecorder Integration Edge Cases', () => {
+    beforeEach(() => {
+      jest.useFakeTimers();
+    });
+
+    afterEach(() => {
+      jest.useRealTimers();
+    });
+
     it('handles different states of MediaRecorder safely', async () => {
       // Start recording
       await audioHandler.startRecordingFlow();
@@ -308,6 +316,14 @@ describe('AudioHandler Integration', () => {
   });
   
   describe('Timer Accuracy During Long Recordings', () => {
+    beforeEach(() => {
+      jest.useFakeTimers();
+    });
+
+    afterEach(() => {
+      jest.useRealTimers();
+    });
+
     it('maintains accurate timer during recording sessions', async () => {
       // Mock Date.now for controlled testing
       const originalDateNow = Date.now;

--- a/tests/error-recovery.test.js
+++ b/tests/error-recovery.test.js
@@ -349,6 +349,14 @@ describe('Error Recovery Scenarios', () => {
   });
   
   describe('Configuration Recovery', () => {
+    beforeEach(() => {
+      jest.useFakeTimers();
+    });
+
+    afterEach(() => {
+      jest.useRealTimers();
+    });
+
     it('should automatically open settings modal when API configuration is missing', async () => {
       // Make validateConfig throw a configuration error
       mockApiClient.validateConfig.mockImplementationOnce(() => {

--- a/tests/recording-integration.test.js
+++ b/tests/recording-integration.test.js
@@ -345,6 +345,14 @@ describe('Recording Integration', () => {
   });
   
   describe('Error Recovery During Recording', () => {
+    beforeEach(() => {
+      jest.useFakeTimers();
+    });
+
+    afterEach(() => {
+      jest.useRealTimers();
+    });
+
     it('should handle API validation errors', async () => {
       // Make validateConfig throw an error
       mockApiClient.validateConfig.mockImplementation(() => {
@@ -423,6 +431,14 @@ describe('Recording Integration', () => {
   });
 
   describe('Timer Integration', () => {
+    beforeEach(() => {
+      jest.useFakeTimers();
+    });
+
+    afterEach(() => {
+      jest.useRealTimers();
+    });
+
     it('should update timer correctly during recording', async () => {
       // Mock Date.now to control time
       const originalDateNow = Date.now;


### PR DESCRIPTION
## Summary
- enable jest fake timers for timer-driven tests
- reset timers in `afterEach`

## Testing
- `npm test` *(fails: TypeError: settings.validateConfiguration is not a function)*

------
https://chatgpt.com/codex/tasks/task_e_6866eaa34adc832ebd87112080a95cd2