### PR TITLE
Fix settings workflow persistence

### DIFF
--- a/js/settings.js
+++ b/js/settings.js
@@ -426,7 +426,14 @@ export class Settings {
             hasUri: !!targetUri,
             hasApiKey: !!apiKey
         });
-        
+
+        // Emit SETTINGS_LOADED to mirror initial load behavior
+        eventBus.emit(APP_EVENTS.SETTINGS_LOADED, {
+            model: currentModel,
+            hasUri: !!targetUri,
+            hasApiKey: !!apiKey
+        });
+
         // Also emit settings updated for compatibility
         eventBus.emit(APP_EVENTS.SETTINGS_UPDATED);
         

--- a/tests/settings-save-modal.vitest.js
+++ b/tests/settings-save-modal.vitest.js
@@ -147,6 +147,15 @@ describe('Settings Modal Save Functionality', () => {
                     hasApiKey: true
                 })
             );
+
+            expect(eventSpy).toHaveBeenCalledWith(
+                APP_EVENTS.SETTINGS_LOADED,
+                expect.objectContaining({
+                    model: 'whisper',
+                    hasUri: true,
+                    hasApiKey: true
+                })
+            );
         });
 
         it('should save valid GPT-4o configuration and close modal', () => {
@@ -188,6 +197,15 @@ describe('Settings Modal Save Functionality', () => {
                     hasApiKey: true
                 })
             );
+
+            expect(eventSpy).toHaveBeenCalledWith(
+                APP_EVENTS.SETTINGS_LOADED,
+                expect.objectContaining({
+                    model: 'gpt-4o-transcribe',
+                    hasUri: true,
+                    hasApiKey: true
+                })
+            );
         });
     });
 
@@ -221,6 +239,11 @@ describe('Settings Modal Save Functionality', () => {
                 APP_EVENTS.SETTINGS_SAVED,
                 expect.anything()
             );
+
+            expect(eventSpy).not.toHaveBeenCalledWith(
+                APP_EVENTS.SETTINGS_LOADED,
+                expect.anything()
+            );
         });
 
         it('should not close modal when URI is invalid', () => {
@@ -246,6 +269,11 @@ describe('Settings Modal Save Functionality', () => {
                     temporary: true
                 })
             );
+
+            expect(eventSpy).not.toHaveBeenCalledWith(
+                APP_EVENTS.SETTINGS_LOADED,
+                expect.anything()
+            );
         });
 
         it('should not close modal when API key format is invalid', () => {
@@ -270,6 +298,11 @@ describe('Settings Modal Save Functionality', () => {
                     type: 'error',
                     temporary: true
                 })
+            );
+
+            expect(eventSpy).not.toHaveBeenCalledWith(
+                APP_EVENTS.SETTINGS_LOADED,
+                expect.anything()
             );
         });
     });
@@ -367,6 +400,15 @@ describe('Settings Modal Save Functionality', () => {
 
             expect(eventSpy).toHaveBeenCalledWith(
                 APP_EVENTS.SETTINGS_UPDATED
+            );
+
+            expect(eventSpy).toHaveBeenCalledWith(
+                APP_EVENTS.SETTINGS_LOADED,
+                expect.objectContaining({
+                    model: 'whisper',
+                    hasUri: true,
+                    hasApiKey: true
+                })
             );
         });
     });

--- a/tests/settings-workflow-fixes.vitest.js
+++ b/tests/settings-workflow-fixes.vitest.js
@@ -338,8 +338,8 @@ describe('Settings Workflow Issues - Fixes Verification (Issue #34)', () => {
 
             // Wait for event processing
             await vi.waitFor(() => {
-                expect(eventBusEmitSpy).toHaveBeenCalledWith(APP_EVENTS.SETTINGS_SAVED, expect.any(Object));
-            });
+            expect(eventBusEmitSpy).toHaveBeenCalledWith(APP_EVENTS.SETTINGS_SAVED, expect.any(Object));
+        });
 
             // Assert - Complete save workflow should work:
             
@@ -360,6 +360,13 @@ describe('Settings Workflow Issues - Fixes Verification (Issue #34)', () => {
             
             // 4. SETTINGS_SAVED event should be emitted
             expect(eventBusEmitSpy).toHaveBeenCalledWith(APP_EVENTS.SETTINGS_SAVED, expect.objectContaining({
+                model: 'whisper',
+                hasUri: true,
+                hasApiKey: true
+            }));
+
+            // 4b. SETTINGS_LOADED event should also be emitted
+            expect(eventBusEmitSpy).toHaveBeenCalledWith(APP_EVENTS.SETTINGS_LOADED, expect.objectContaining({
                 model: 'whisper',
                 hasUri: true,
                 hasApiKey: true

--- a/tests/settings-workflow-issues.vitest.js
+++ b/tests/settings-workflow-issues.vitest.js
@@ -188,6 +188,16 @@ describe('Settings Save Workflow Issues - Issue #32', () => {
                 })
             );
 
+            // Verify SETTINGS_LOADED event is emitted for persistence
+            expect(eventSpy).toHaveBeenCalledWith(
+                APP_EVENTS.SETTINGS_LOADED,
+                expect.objectContaining({
+                    model: 'whisper',
+                    hasUri: true,
+                    hasApiKey: true
+                })
+            );
+
             // Verify settings updated event is emitted
             expect(eventSpy).toHaveBeenCalledWith(APP_EVENTS.SETTINGS_UPDATED);
         });
@@ -311,6 +321,12 @@ describe('Settings Save Workflow Issues - Issue #32', () => {
             // Verify SETTINGS_SAVED event is NOT emitted
             expect(eventSpy).not.toHaveBeenCalledWith(
                 APP_EVENTS.SETTINGS_SAVED,
+                expect.anything()
+            );
+
+            // Verify SETTINGS_LOADED event is NOT emitted
+            expect(eventSpy).not.toHaveBeenCalledWith(
+                APP_EVENTS.SETTINGS_LOADED,
                 expect.anything()
             );
         });


### PR DESCRIPTION
## Summary
- emit `SETTINGS_LOADED` after saving configuration so other modules can react like on page load
- update tests for new event emission

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6876e5b9706c832ebed8c942f7fcd035