### PR TITLE
Remove Clear button, rename Cut→Grab, and fix status toast colour clobber

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,9 +18,10 @@ there's something real to lose.
   scaling the buttons themselves.
 - **Autosave + restore** — your transcript is saved to the browser as you go and
   offered back after a reload, so a refresh never costs you work.
-- **Cut · Restore · Clear** — Cut lifts the transcript to your clipboard; Restore
-  brings back the last cut if you clobbered the clipboard by accident; Clear
-  empties the box. New transcriptions always append, separated by a divider.
+- **Grab · Restore** — Grab lifts the transcript to your clipboard and empties
+  the box; Restore brings it back if you clobbered the clipboard by accident, so
+  the take-it-away action is always recoverable. New transcriptions always
+  append, separated by a divider.
 - **Proportional confirm** — discarding a throwaway clip (under ~10s) just
   happens; discarding a substantial recording asks once, by name. No rote
   "are you sure?" dialogs.

--- a/css/styles.css
+++ b/css/styles.css
@@ -873,14 +873,14 @@ header {
     box-shadow: var(--focus-ring);
 }
 
-/* Transcript action row: Restore · Clear · Cut */
+/* Transcript action row: Restore · Grab */
 .transcript-actions {
     display: flex;
     align-items: center;
     gap: 0.5rem;
 }
 
-/* Cut — the primary transcript action, gently emphasised */
+/* Grab — the primary transcript action, gently emphasised */
 .clear-btn-primary {
     border-color: var(--accent);
     color: var(--accent);

--- a/index.html
+++ b/index.html
@@ -144,19 +144,12 @@
                         </svg>
                         Restore
                     </button>
-                    <button id="clear-button" class="clear-btn" aria-label="Clear transcript">
-                        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
-                            <polyline points="3 6 5 6 21 6"></polyline>
-                            <path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6m3 0V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2"></path>
-                        </svg>
-                        Clear
-                    </button>
-                    <button id="grab-text-button" class="clear-btn clear-btn-primary" aria-label="Cut text to clipboard">
+                    <button id="grab-text-button" class="clear-btn clear-btn-primary" aria-label="Grab text to clipboard">
                         <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
                             <rect x="9" y="9" width="13" height="13" rx="2" ry="2"></rect>
                             <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"></path>
                         </svg>
-                        Cut
+                        Grab
                     </button>
                 </div>
             </div>

--- a/js/constants.js
+++ b/js/constants.js
@@ -154,7 +154,6 @@ export const ID = Object.freeze({
   CANCEL_BUTTON:    'cancel-button',
   SETTINGS_BUTTON:  'settings-button',
   GRAB_TEXT_BUTTON: 'grab-text-button',
-  CLEAR_BUTTON:     'clear-button',
   RESTORE_BUTTON:   'restore-button',
   SAVE_SETTINGS:    'save-settings',
   THEME_TOGGLE:     'theme-toggle',
@@ -309,10 +308,9 @@ export const MESSAGES = {
   TRANSCRIPTION_COMPLETE: 'Transcription complete',
   
   // Clipboard Operations
-  TEXT_CUT_SUCCESS: 'Text cut to clipboard',
-  TEXT_CUT_FAILED: 'Failed to cut text',
-  NO_TEXT_TO_CUT: 'No text to cut',
-  TEXT_CLEARED: 'Transcript cleared',
+  TEXT_GRAB_SUCCESS: 'Grabbed to clipboard',
+  TEXT_GRAB_FAILED: 'Failed to grab text',
+  NO_TEXT_TO_GRAB: 'No text to grab',
   TRANSCRIPT_RESTORED: 'Transcript restored',
   
   // Permission Instructions

--- a/js/status-helper.js
+++ b/js/status-helper.js
@@ -41,6 +41,9 @@ export function showTemporaryStatus(
     }
     // Drop any stale inline colour from earlier inline-styled status writes.
     element.style.color = '';
+    // A fresh toast takes ownership of the line: clear any base message that was
+    // deferred during a previous toast (see setStatus's defer-while-active rule).
+    element._pendingBaseStatus = undefined;
 
     // Clear any existing timeout on the element
     if (element._statusTimeout) {
@@ -53,10 +56,14 @@ export function showTemporaryStatus(
         element._statusTimeout = setTimeout(() => {
             // Only reset if the message has not been changed meanwhile
             if (element.textContent === originalMessage) {
-                element.textContent = resetMessage;
+                // Revert to the latest base message deferred while this toast was
+                // showing (a base setStatus during the toast), else the caller's
+                // reset message.
+                element.textContent = element._pendingBaseStatus ?? resetMessage;
                 clearStatusType(element);
                 element.style.color = '';
             }
+            element._pendingBaseStatus = undefined;
             element._statusTimeout = null;
         }, duration);
     }

--- a/js/transcript-store.js
+++ b/js/transcript-store.js
@@ -2,8 +2,8 @@
  * @fileoverview Thin storage gateway for the single-slot transcript record.
  *
  * The transcript text is the most valuable thing the app produces, so it must
- * never be lost to a reload, crash, or a mistimed Cut. This
- * store keeps exactly ONE slot — the last meaningful transcript — and exposes a
+ * never be lost to a reload, crash, or a mistimed Grab. This store keeps exactly
+ * ONE slot — the last meaningful transcript — and exposes a
  * deliberately small interface (save/load/clear/has). localStorage backs it
  * today; the interface is the seam that lets a future backend (e.g. Cosmos DB)
  * swap in without touching any UI code.

--- a/js/ui.js
+++ b/js/ui.js
@@ -29,7 +29,6 @@ export class UI {
         this.statusElement = document.getElementById(ID.STATUS);
         this.transcriptElement = document.getElementById(ID.TRANSCRIPT);
         this.grabTextButton = document.getElementById(ID.GRAB_TEXT_BUTTON);
-        this.clearButton = document.getElementById(ID.CLEAR_BUTTON);
         this.restoreButton = document.getElementById(ID.RESTORE_BUTTON);
         this.timerElement = document.getElementById(ID.TIMER);
         this.spinnerContainer = document.getElementById(ID.SPINNER_CONTAINER);
@@ -151,12 +150,9 @@ export class UI {
             });
         }
 
-        // Transcript actions — Cut (grab + clear), Clear (wipe), Restore (recover).
+        // Transcript actions — Grab (copy + clear, recoverable) and Restore (recover).
         if (this.grabTextButton) {
-            this.grabTextButton.addEventListener('click', () => this.cutTranscript());
-        }
-        if (this.clearButton) {
-            this.clearButton.addEventListener('click', () => this.clearTranscript());
+            this.grabTextButton.addEventListener('click', () => this.grabTranscript());
         }
         if (this.restoreButton) {
             this.restoreButton.addEventListener('click', () => this.restoreTranscript());
@@ -829,16 +825,17 @@ export class UI {
     }
 
     /**
-     * Cut — copy the transcript to the clipboard and clear the box. The record is
-     * persisted FIRST, so the words survive a clipboard failure or later clobber.
+     * Grab — copy the transcript to the clipboard and clear the box. The record is
+     * persisted FIRST, so the words survive a clipboard failure or later clobber,
+     * and remain recoverable via Restore.
      *
-     * @method cutTranscript
+     * @method grabTranscript
      * @returns {Promise<boolean>} Resolves true when the text reached the clipboard.
      */
-    cutTranscript() {
+    grabTranscript() {
         const text = this.transcriptElement.value;
         if (!text) {
-            this._emitStatus(MESSAGES.NO_TEXT_TO_CUT, 'error');
+            this._emitStatus(MESSAGES.NO_TEXT_TO_GRAB, 'error');
             return Promise.resolve(false);
         }
         this.persistTranscript();
@@ -848,37 +845,18 @@ export class UI {
                 this._autosaveTimer = null;
                 this.transcriptElement.value = '';
                 this.updateRestoreAffordance();
-                this._emitStatus(MESSAGES.TEXT_CUT_SUCCESS, 'success');
+                this._emitStatus(MESSAGES.TEXT_GRAB_SUCCESS, 'success');
                 return true;
             })
             .catch(() => {
-                this._emitStatus(MESSAGES.TEXT_CUT_FAILED, 'error');
+                this._emitStatus(MESSAGES.TEXT_GRAB_FAILED, 'error');
                 return false;
             });
     }
 
     /**
-     * Clear — wipe the box WITHOUT copying and purge the recovery slot. Cut is the
-     * recoverable clear path; Clear is the explicit empty.
-     *
-     * @method clearTranscript
-     * @returns {void}
-     */
-    clearTranscript() {
-        const hasText = Boolean(this.transcriptElement.value);
-        const hasStoredText = Boolean(this.transcriptStore && this.transcriptStore.has());
-        if (!hasText && !hasStoredText) return;
-        this.transcriptElement.value = '';
-        if (this.transcriptStore) {
-            this.transcriptStore.clear();
-        }
-        this.updateRestoreAffordance();
-        this._emitStatus(MESSAGES.TEXT_CLEARED);
-    }
-
-    /**
      * Restore — resurrect the last transcript into the box. Persistent and
-     * repeatable: Cut → clobbered clipboard → Restore → Cut again all work.
+     * repeatable: Grab → clobbered clipboard → Restore → Grab again all work.
      *
      * @method restoreTranscript
      * @returns {void}

--- a/js/ui.js
+++ b/js/ui.js
@@ -713,15 +713,19 @@ export class UI {
     // ───────────────────────── Status + transcript ─────────────────────────
 
     setStatus(message) {
+        // While a temporary toast (success/error feedback) owns the status line,
+        // defer this base message to become the toast's revert target instead of
+        // stripping the toast's colour. The toast reverts to it when it expires.
         if (this.statusElement._statusTimeout) {
-            clearTimeout(this.statusElement._statusTimeout);
-            this.statusElement._statusTimeout = null;
+            this.statusElement._pendingBaseStatus = message;
+            return;
         }
         this.statusElement.textContent = message;
         // Return to the base (AA-safe) colour: drop any temporary type modifier.
         if (this.statusElement.classList) {
             this.statusElement.classList.remove(...STATUS_TYPE_CLASSES);
         }
+        this.statusElement._pendingBaseStatus = undefined;
         this.statusElement.style.color = '';
     }
 

--- a/tests/status-ownership.vitest.js
+++ b/tests/status-ownership.vitest.js
@@ -1,0 +1,77 @@
+/**
+ * @fileoverview Status-line ownership — a temporary success/error toast must keep
+ * its colour for its full duration even when a base `setStatus` races in, then
+ * revert to the LATEST base message. Exercises the REAL `showTemporaryStatus` +
+ * REAL `setStatus` on one real element (no mocks) — the production interaction
+ * that the helper-in-isolation tests and the helper-mocking tests can't see.
+ */
+
+import { vi } from 'vitest';
+import { showTemporaryStatus } from '../js/status-helper.js';
+import { UI } from '../js/ui.js';
+
+// Invoke the REAL setStatus against a bare context (mirrors status-reset.vitest.js).
+const baseSetStatus = (el, msg) => UI.prototype.setStatus.call({ statusElement: el }, msg);
+
+describe('Status line ownership (toast vs base setStatus)', () => {
+    let el;
+
+    beforeEach(() => {
+        vi.useFakeTimers();
+        el = document.createElement('div'); // happy-dom: real classList + style
+        el.className = 'status';
+    });
+
+    afterEach(() => {
+        vi.useRealTimers();
+    });
+
+    it('keeps the success colour when a base setStatus races during the toast', () => {
+        showTemporaryStatus(el, 'Grabbed to clipboard', 'success', 3000, 'ready');
+        expect(el.classList.contains('status--success')).toBe(true);
+        expect(el.textContent).toBe('Grabbed to clipboard');
+
+        // A prerequisite / FSM base write lands mid-toast — must NOT clobber it.
+        baseSetStatus(el, '🎙️ Click the microphone to start recording');
+
+        expect(el.textContent).toBe('Grabbed to clipboard');
+        expect(el.classList.contains('status--success')).toBe(true);
+        expect(el._statusTimeout).toBeTruthy();
+    });
+
+    it('reverts to the deferred base message (not the original reset) after the toast', () => {
+        showTemporaryStatus(el, 'Grabbed to clipboard', 'success', 3000, 'original-reset');
+        baseSetStatus(el, 'latest base message');
+
+        vi.advanceTimersByTime(3000);
+
+        expect(el.textContent).toBe('latest base message');
+        expect(el.classList.contains('status--success')).toBe(false);
+        expect(el.style.color).toBe('');
+        expect(el._statusTimeout).toBeNull();
+    });
+
+    it('falls back to the reset message when no base write was deferred', () => {
+        showTemporaryStatus(el, 'Transcript restored', 'success', 3000, 'idle prompt');
+        vi.advanceTimersByTime(3000);
+        expect(el.textContent).toBe('idle prompt');
+        expect(el.classList.contains('status--success')).toBe(false);
+    });
+
+    it('lets a newer error toast override an active success toast', () => {
+        showTemporaryStatus(el, 'Grabbed to clipboard', 'success', 3000, 'ready');
+        showTemporaryStatus(el, 'Failed to grab text', 'error', 3000, 'ready');
+
+        expect(el.textContent).toBe('Failed to grab text');
+        expect(el.classList.contains('status--error')).toBe(true);
+        expect(el.classList.contains('status--success')).toBe(false);
+    });
+
+    it('a base setStatus with no active toast still writes and strips type classes', () => {
+        el.classList.add('status--success'); // stale modifier, no toast armed
+        baseSetStatus(el, 'hello');
+        expect(el.textContent).toBe('hello');
+        expect(el.classList.contains('status--success')).toBe(false);
+        expect(el._statusTimeout == null).toBe(true);
+    });
+});

--- a/tests/status-reset.vitest.js
+++ b/tests/status-reset.vitest.js
@@ -4,18 +4,21 @@ import { UI } from '../js/ui.js';
 
 
 describe('status resets', () => {
-  it('does not reset if status updated before timeout', () => {
+  it('defers a base setStatus during a toast, then reverts to it when the toast ends', () => {
     vi.useFakeTimers();
     const el = { textContent: '', style: { color: '' } };
 
     showTemporaryStatus(el, 'temp', 'info', 1000, 'reset');
 
-    // Update status before the timeout fires
+    // A base update during the active toast must NOT clobber it immediately —
+    // the toast owns the line and the base message is deferred.
     UI.prototype.setStatus.call({ statusElement: el }, 'new');
+    expect(el.textContent).toBe('temp');
 
+    // When the toast expires it reverts to the deferred base message, not 'reset'.
     vi.runAllTimers();
-
     expect(el.textContent).toBe('new');
+
     vi.useRealTimers();
   });
 });

--- a/tests/transcript-actions.vitest.js
+++ b/tests/transcript-actions.vitest.js
@@ -1,7 +1,7 @@
 /**
- * @fileoverview Phase 2 — Cut / Restore / Clear actions and append-with-divider.
- * Cut grabs+clears (record survives), Restore is persistent & repeatable, Clear
- * purges the box and recovery slot, and re-recordings append with a visible divider.
+ * @fileoverview Transcript actions — Grab / Restore and append-with-divider.
+ * Grab copies+clears (the record survives, recoverable via Restore), Restore is
+ * persistent & repeatable, and re-recordings append with a visible divider.
  */
 
 import { vi } from 'vitest';
@@ -36,7 +36,7 @@ function makeStorage(initial = {}) {
     };
 }
 
-describe('Transcript actions: Cut / Restore / Clear / append', () => {
+describe('Transcript actions: Grab / Restore / append', () => {
     let ui;
     let store;
     let writeText;
@@ -55,20 +55,20 @@ describe('Transcript actions: Cut / Restore / Clear / append', () => {
         resetEventBus();
     });
 
-    describe('Cut', () => {
+    describe('Grab', () => {
         it('copies to the clipboard, clears the box, but keeps the record', async () => {
             ui.transcriptElement.value = 'grab me';
-            const ok = await ui.cutTranscript();
+            const ok = await ui.grabTranscript();
             expect(ok).toBe(true);
             expect(writeText).toHaveBeenCalledWith('grab me');
             expect(ui.transcriptElement.value).toBe('');
-            expect(store.load()?.text).toBe('grab me');      // survives the Cut
+            expect(store.load()?.text).toBe('grab me');      // survives the Grab
             expect(ui.restoreButton.hidden).toBe(false);     // Restore now offered
         });
 
         it('does nothing on an empty box', async () => {
             ui.transcriptElement.value = '';
-            const ok = await ui.cutTranscript();
+            const ok = await ui.grabTranscript();
             expect(ok).toBe(false);
             expect(writeText).not.toHaveBeenCalled();
         });
@@ -76,19 +76,19 @@ describe('Transcript actions: Cut / Restore / Clear / append', () => {
         it('keeps the text in the box AND recoverable if the clipboard write fails', async () => {
             writeText.mockImplementationOnce(() => Promise.reject(new Error('blocked')));
             ui.transcriptElement.value = 'precious';
-            const ok = await ui.cutTranscript();
+            const ok = await ui.grabTranscript();
             expect(ok).toBe(false);
             expect(ui.transcriptElement.value).toBe('precious'); // not lost from the box
             expect(store.load()?.text).toBe('precious');         // and saved as a record
         });
 
-        it('cancels a pending empty autosave when Cut clears the box', async () => {
+        it('cancels a pending empty autosave when Grab clears the box', async () => {
             vi.useFakeTimers();
             try {
                 ui.transcriptElement.value = 'grab me';
                 ui._autosaveTimer = setTimeout(() => ui.persistTranscript(), 500);
 
-                const ok = await ui.cutTranscript();
+                const ok = await ui.grabTranscript();
                 await vi.advanceTimersByTimeAsync(500);
 
                 expect(ok).toBe(true);
@@ -101,31 +101,11 @@ describe('Transcript actions: Cut / Restore / Clear / append', () => {
         });
     });
 
-    describe('Clear', () => {
-        it('wipes the box without copying and clears the recovery slot', () => {
-            store.save('previous saved text');
-            ui.transcriptElement.value = 'discard from box';
-            ui.clearTranscript();
-            expect(writeText).not.toHaveBeenCalled();
-            expect(ui.transcriptElement.value).toBe('');
-            expect(store.load()).toBeNull();
-            expect(ui.restoreButton.hidden).toBe(true);
-        });
-
-        it('also clears a restore slot when the box is already empty', () => {
-            store.save('cut text');
-            ui.transcriptElement.value = '';
-            ui.clearTranscript();
-            expect(store.load()).toBeNull();
-            expect(ui.restoreButton.hidden).toBe(true);
-        });
-    });
-
     describe('Restore', () => {
         it('resurrects the last transcript and is repeatable (non-consuming)', async () => {
-            // First Cut leaves a recoverable record + empty box.
+            // First Grab leaves a recoverable record + empty box.
             ui.transcriptElement.value = 'round one';
-            await ui.cutTranscript();
+            await ui.grabTranscript();
             expect(ui.transcriptElement.value).toBe('');
 
             // Restore brings it back.
@@ -133,8 +113,8 @@ describe('Transcript actions: Cut / Restore / Clear / append', () => {
             expect(ui.transcriptElement.value).toBe('round one');
             expect(ui.restoreButton.hidden).toBe(true); // box non-empty now
 
-            // Cut again, restore again — the slot was never consumed.
-            await ui.cutTranscript();
+            // Grab again, restore again — the slot was never consumed.
+            await ui.grabTranscript();
             expect(ui.transcriptElement.value).toBe('');
             ui.restoreTranscript();
             expect(ui.transcriptElement.value).toBe('round one');


### PR DESCRIPTION
Two related polish fixes on top of 2.0.

## 1. Remove the Clear button; rename Cut → Grab

`Clear` was a silent, **unrecoverable** wipe sitting one careless click from `Cut` — and Restore only ever appears as the undo *for* Cut, so a mis-clicked Clear had no backup. It's removed. The transcript actions are now just **Restore + Grab**, where Grab is the recoverable take-it-away path.

The action is also renamed **Cut → Grab** everywhere (visible label, aria-label, the `grabTranscript()` method, and the clipboard messages), aligning the code with the element's existing `grab-text-button` id. Success status now reads "Grabbed to clipboard".

## 2. Fix status toast colour being clobbered by a racing base update

A non-temporary base status write (`setStatus`) that fires while a temporary success/error **toast** is showing stripped the toast's colour and replaced its text before its 3s elapsed.

This is reachable in a real flow: **saving settings** emits a green "Settings saved" toast *and* `SETTINGS_SAVED`, whose handler runs `checkRecordingPrerequisites → setStatus(...)`, instantly replacing the green confirmation with the grey base prompt (verified). Grab/Restore happen not to fire a follow-up base write, so their teal showed fine — which is why this hid.

**Fix — an active toast owns the status line:** while a toast is active, `setStatus` defers the base message (it becomes the toast's revert target) instead of writing/stripping; the toast reverts to the latest deferred base when it expires. A newer toast still overrides immediately.

A new real-DOM regression test (`tests/status-ownership.vitest.js`) exercises the real `showTemporaryStatus` + `setStatus` interaction on one element — the prior tests mock the helper, so this race was invisible to them.

## Verification
`378 tests pass · lint clean · knip clean · coverage 92.47 / 87 / 90.3 / 92.47 (gates 85/80/70/85)`. Both fixes confirmed live in a browser on fresh (uncached) code: settings-saved toast survives the re-check, Grab shows + holds teal, only Restore + Grab render in the action row.

🤖 Generated with [Claude Code](https://claude.com/claude-code)