### PR TITLE
chore(ci): add GitHub Actions workflow enforcing lint, coverage, deps and size gates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,37 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  checks:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Lint
+        run: npm run lint
+
+      - name: Tests with coverage thresholds
+        run: npm run test:coverage
+
+      - name: Production dependency check (knip)
+        run: npm run deps:check:prod
+
+      - name: Size budget
+        run: npm run size


### PR DESCRIPTION
Adds a single CI workflow that runs the repo's existing quality gates server-side on every PR and push to `main`:

- `npm run lint` (ESLint)
- `npm run test:coverage` (Vitest, thresholds: statements 85 / branches 80 / functions 70 / lines 85)
- `npm run deps:check:prod` (knip — guards the zero-runtime-deps rule)
- `npm run size` (size-limit budget)

Until now these ran only in local husky hooks, which `git push --no-verify` bypasses and which don't gate GitHub-UI merges. Nothing new is invented — CI runs exactly what the hooks already run.

Implements `plans/002-add-github-actions-ci.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)