### PR TITLE
fix(tooling): anchor test globs so quality gates measure only the repo

### DIFF
--- a/knip.json
+++ b/knip.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://unpkg.com/knip@5/schema.json",
-  "entry": ["js/main.js"],
+  "entry": ["js/main.js", "js/*.worker.js"],
   "project": ["js/**/*.js"],
   "ignore": [
     "coverage/**",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,13 @@
 {
   "name": "whisper-transcribe",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "whisper-transcribe",
-      "version": "1.0.0",
+      "version": "2.0.0",
+      "license": "MIT",
       "devDependencies": {
         "@eslint/js": "^9.30.1",
         "@size-limit/file": "^11.2.0",
@@ -18,6 +19,9 @@
         "knip": "^5.61.3",
         "size-limit": "^11.2.0",
         "vitest": "^3.2.4"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/@ampproject/remapping": {

--- a/package.json
+++ b/package.json
@@ -5,6 +5,9 @@
   "license": "MIT",
   "description": "A no-build browser app that turns speech into text with Azure Speech Services, wrapped in an interaction-led Dynamic Island UI.",
   "type": "module",
+  "engines": {
+    "node": ">=20"
+  },
   "scripts": {
     "test": "vitest run",
     "test:watch": "vitest --watch",

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -1,11 +1,12 @@
 /// <reference types="vitest" />
-import { defineConfig } from 'vitest/config';
+import { defineConfig, configDefaults } from 'vitest/config';
 
 export default defineConfig({
   test: {
     environment: 'happy-dom',
     setupFiles: ['./tests/vitest-setup.js'],
-    include: ['**/tests/**/*.vitest.js'],
+    include: ['tests/**/*.vitest.js'],
+    exclude: [...configDefaults.exclude, '**/.claude/**'],
     testTimeout: 10000,
     coverage: {
       provider: 'v8',


### PR DESCRIPTION
Makes the local quality gates measure only the real repo. Implements `plans/003-make-quality-gates-measure-only-the-repo.md` (executed by a dispatched agent in an isolated worktree, reviewed against the plan's done criteria).

- **vitest**: anchor `include` to `tests/**/*.vitest.js` and exclude `**/.claude/**` — a bare `vitest run` in a checkout containing agent worktrees was running the suite twice (756 tests instead of 378), making the local pre-push gate depend on unmerged branch state. Adversarially verified: a test file planted under `.claude/worktrees/` is no longer picked up.
- **knip**: declare `js/*.worker.js` as an entry — removes the standing "Unused file" false positive on the load-bearing `audio-converter.worker.js` (knip can't trace `new Worker(new URL(...))`).
- **package.json**: add `engines: { node: ">=20" }` (ESLint 9 / Vitest 3 / knip 5 all need modern Node).
- **package-lock.json**: root version synced 1.0.0 → 2.0.0; no dependency changes.

CI itself was never affected (clean checkouts have no `.claude/`); this fixes the local gates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)