### PR TITLE
fix(status): define INVALID_REQUEST message and source FSM status text from MESSAGES

### DIFF
--- a/js/constants.js
+++ b/js/constants.js
@@ -282,7 +282,7 @@ export const MESSAGES = {
   INVALID_API_KEY_CHARACTERS: 'API key contains unsupported characters. Paste only the raw Speech resource key.',
   
   // Recording States
-  RECORDING_IN_PROGRESS: 'Recording... Click again to stop',
+  RECORDING_IN_PROGRESS: 'Recording... Click to stop',
   RECORDING_PAUSED: 'Recording paused',
   RECORDING_CANCELLED: 'Recording cancelled',
   FINISHING_RECORDING: 'Finishing...',
@@ -323,6 +323,7 @@ export const MESSAGES = {
   ERROR_PREFIX: 'Error: ',
   MICROPHONE_IN_USE: '⚠️ Microphone is already in use by another application.',
   MICROPHONE_NOT_SUITABLE: '⚠️ No microphone meets the requirements. Try with a different microphone.',
+  INVALID_REQUEST: '⚠️ Microphone request was invalid. Please refresh the page and try again.',
   // Generic error message for unexpected errors
   ERROR_OCCURRED: 'An unexpected error occurred',
   TAP_MIC_TO_RETRY: 'Tap mic to retry',

--- a/js/recording-state-machine.js
+++ b/js/recording-state-machine.js
@@ -158,7 +158,7 @@ export class RecordingStateMachine {
     async handleRecordingState() {
         eventBus.emit(APP_EVENTS.RECORDING_STARTED);
         eventBus.emit(APP_EVENTS.UI_STATUS_UPDATE, {
-            message: 'Recording... Click to stop',
+            message: MESSAGES.RECORDING_IN_PROGRESS,
             type: 'info'
         });
     }
@@ -176,7 +176,7 @@ export class RecordingStateMachine {
     async handlePausedState() {
         eventBus.emit(APP_EVENTS.RECORDING_PAUSED);
         eventBus.emit(APP_EVENTS.UI_STATUS_UPDATE, {
-            message: 'Recording paused',
+            message: MESSAGES.RECORDING_PAUSED,
             type: 'info'
         });
     }

--- a/tests/permission-manager.vitest.js
+++ b/tests/permission-manager.vitest.js
@@ -224,6 +224,25 @@ describe('PermissionManager', () => {
                 })
             );
         });
+
+        it('should handle invalid request (TypeError) error', async () => {
+            // getUserMedia throws TypeError on invalid constraints / insecure context
+            const invalidRequestError = new TypeError('Invalid constraints');
+            mockGetUserMedia.mockRejectedValueOnce(invalidRequestError);
+
+            const stream = await permissionManager.requestMicrophoneAccess();
+
+            expect(stream).toBeNull();
+            // The message must be the defined constant, never the literal string "undefined"
+            expect(MESSAGES.INVALID_REQUEST).toBeDefined();
+            expect(eventBusEmitSpy).toHaveBeenCalledWith(
+                APP_EVENTS.UI_STATUS_UPDATE,
+                expect.objectContaining({
+                    message: MESSAGES.INVALID_REQUEST,
+                    type: 'error'
+                })
+            );
+        });
     });
     
     describe('Permission Status Changes', () => {

--- a/tests/recording-state-machine.vitest.js
+++ b/tests/recording-state-machine.vitest.js
@@ -123,6 +123,16 @@ describe('RecordingStateMachine direct behavior', () => {
     });
     expect(emitSpy).toHaveBeenCalledWith(APP_EVENTS.RECORDING_STARTED);
     expect(emitSpy).toHaveBeenCalledWith(APP_EVENTS.RECORDING_PAUSED);
+    // Status text is sourced from MESSAGES, not literals, so copy changes
+    // happen in one place (constants.js) without breaking these assertions.
+    expect(emitSpy).toHaveBeenCalledWith(APP_EVENTS.UI_STATUS_UPDATE, {
+      message: MESSAGES.RECORDING_IN_PROGRESS,
+      type: 'info'
+    });
+    expect(emitSpy).toHaveBeenCalledWith(APP_EVENTS.UI_STATUS_UPDATE, {
+      message: MESSAGES.RECORDING_PAUSED,
+      type: 'info'
+    });
   });
 
   it('emits expected events for stopping and processing handlers', async () => {


### PR DESCRIPTION
Implements `plans/005-fix-undefined-mic-error-and-fsm-status-drift.md` (executed by a dispatched agent in an isolated worktree, reviewed against the plan's done criteria).

- **Bug**: `getUserMedia` `TypeError` failures rendered the literal string `undefined` as the status — `js/permission-manager.js:228` referenced `MESSAGES.INVALID_REQUEST`, a key that didn't exist. The constant now exists (matching the ⚠️-prefixed style of its siblings) and a regression test drives a real TypeError through `requestMicrophoneAccess()`.
- **Constants discipline**: the FSM emitted hardcoded status strings ('Recording... Click to stop' / 'Recording paused') while the matching `MESSAGES` constants sat unused with drifted wording. The handlers now use the constants; `RECORDING_IN_PROGRESS` adopts the live 2.0 wording so user-visible behavior is byte-identical. Tests assert via the constants, not literals.

Suite: 379 tests passing (+1), coverage thresholds met, lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)