### PR TITLE
fix(security): enforce https on the endpoint URI at the fetch gate

### DIFF
--- a/js/api-client.js
+++ b/js/api-client.js
@@ -403,14 +403,21 @@ export class AzureAPIClient {
         }
         
         // Basic URI validation
+        let parsedUri;
         try {
-            new URL(normalizedConfig.uri);
+            parsedUri = new URL(normalizedConfig.uri);
         } catch {
             const error = new Error(`${MESSAGES.INVALID_URI_FORMAT} for ${normalizedConfig.model}`);
             eventBus.emit(APP_EVENTS.API_CONFIG_MISSING, { missing: 'validUri', model: normalizedConfig.model });
             throw error;
         }
-        
+
+        if (parsedUri.protocol !== 'https:') {
+            const error = new Error(`${MESSAGES.URI_MUST_BE_HTTPS} for ${normalizedConfig.model}`);
+            eventBus.emit(APP_EVENTS.API_CONFIG_MISSING, { missing: 'httpsUri', model: normalizedConfig.model });
+            throw error;
+        }
+
         return normalizedConfig;
     }
 }

--- a/js/constants.js
+++ b/js/constants.js
@@ -279,6 +279,7 @@ export const MESSAGES = {
   API_KEY_REQUIRED: 'API key is required',
   URI_REQUIRED: 'URI is required',
   INVALID_URI_FORMAT: 'Invalid URI format',
+  URI_MUST_BE_HTTPS: 'URI must use HTTPS',
   INVALID_API_KEY_CHARACTERS: 'API key contains unsupported characters. Paste only the raw Speech resource key.',
   
   // Recording States

--- a/js/settings.js
+++ b/js/settings.js
@@ -564,7 +564,7 @@ export class Settings {
             try {
                 const url = new URL(uri);
                 if (url.protocol !== 'https:') {
-                    errors.push('URI must use HTTPS');
+                    errors.push(MESSAGES.URI_MUST_BE_HTTPS);
                 }
             } catch {
                 errors.push(MESSAGES.INVALID_URI_FORMAT);

--- a/tests/api-client-errors.vitest.js
+++ b/tests/api-client-errors.vitest.js
@@ -27,7 +27,7 @@ global.URL = vi.fn((url) => {
     if (!url.startsWith('http')) {
         throw new Error('Invalid URL');
     }
-    return { href: url };
+    return { href: url, protocol: url.startsWith('https') ? 'https:' : 'http:' };
 });
 
 vi.mock('../js/audio-converter.js', () => ({
@@ -218,8 +218,43 @@ describe('AzureAPIClient Error Handling', () => {
                 })
             );
         });
+
+        it('should reject an insecure (http) URI in validateConfig', () => {
+            // Valid API key, but a cleartext http:// endpoint
+            mockSettings.getModelConfig.mockReturnValue({
+                model: 'whisper',
+                apiKey: 'test-api-key',
+                uri: 'http://insecure.openai.azure.com/'
+            });
+
+            // validateConfig() should throw with the HTTPS-required message
+            expect(() => apiClient.validateConfig()).toThrow(MESSAGES.URI_MUST_BE_HTTPS);
+
+            // Should emit API_CONFIG_MISSING with the httpsUri reason
+            expect(eventBusEmitSpy).toHaveBeenCalledWith(
+                APP_EVENTS.API_CONFIG_MISSING,
+                expect.objectContaining({
+                    missing: 'httpsUri',
+                    model: 'whisper'
+                })
+            );
+        });
+
+        it('should not send the request over an insecure (http) URI', async () => {
+            // Valid API key, but a cleartext http:// endpoint
+            mockSettings.getModelConfig.mockReturnValue({
+                model: 'whisper',
+                apiKey: 'test-api-key',
+                uri: 'http://insecure.openai.azure.com/'
+            });
+
+            // transcribe() must reject before any network call leaks the API key
+            await expect(apiClient.transcribe(new Blob())).rejects.toThrow(MESSAGES.URI_MUST_BE_HTTPS);
+
+            expect(global.fetch).not.toHaveBeenCalled();
+        });
     });
-    
+
     describe('Network Failure Handling', () => {
         it('should handle network failures gracefully', async () => {
             // Simulate network failure

--- a/tests/api-client-validation.vitest.js
+++ b/tests/api-client-validation.vitest.js
@@ -18,7 +18,7 @@ global.URL = vi.fn((url) => {
     if (!url || !url.startsWith('http')) {
         throw new Error('Invalid URL');
     }
-    return { href: url };
+    return { href: url, protocol: url.startsWith('https') ? 'https:' : 'http:' };
 });
 
 // Mock dependencies

--- a/tests/mai-transcribe.vitest.js
+++ b/tests/mai-transcribe.vitest.js
@@ -17,7 +17,7 @@ global.URL = vi.fn((url) => {
     if (!url || !url.startsWith('http')) {
         throw new Error('Invalid URL');
     }
-    return { href: url };
+    return { href: url, protocol: url.startsWith('https') ? 'https:' : 'http:' };
 });
 
 global.fetch = vi.fn();


### PR DESCRIPTION
Implements `plans/006-enforce-https-on-endpoint-at-fetch-gate.md` (executed by dispatched agents in an isolated worktree, reviewed against the plan's done criteria).

The `https:` requirement on the Azure endpoint URI was enforced only at settings-save time; `validateConfig()` — the gate that runs immediately before every `fetch` — checked URL syntax but not protocol. Any `http://` URI reaching localStorage by another path (pre-guard persistence, another tab/extension, manual edit) would send the API key header and audio in cleartext.

- `validateConfig()` now rejects non-https URIs with the same emit+throw shape as its sibling checks (`API_CONFIG_MISSING` with `missing: 'httpsUri'`).
- The settings-side `'URI must use HTTPS'` literal moved into `MESSAGES.URI_MUST_BE_HTTPS` (constants discipline) — same string, one source of truth.
- Three test files stubbed `global.URL` without a `protocol` property; the stubs now derive one, matching real URL behavior for their fixtures. (The first executor run caught this and STOPPED cleanly — the plan was revised rather than improvised around.)
- Two new regression tests: the throw/event shape, and `expect(global.fetch).not.toHaveBeenCalled()` on an insecure URI — the key never leaves over cleartext.

Suite: 380 tests passing (+2), coverage thresholds met, lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)