### PR TITLE
fix(api): bound total transcription retry time with an overall deadline

### DIFF
--- a/js/api-client.js
+++ b/js/api-client.js
@@ -2,7 +2,7 @@
  * @fileoverview Azure Speech Services API client for audio transcription.
  */
 
-import { API_KEY_VALUE_PATTERN, MESSAGES, HTTP_METHODS, CONTENT_TYPES, TRANSCRIPTION_TIMEOUT_MS } from './constants.js';
+import { API_KEY_VALUE_PATTERN, MESSAGES, HTTP_METHODS, CONTENT_TYPES, TRANSCRIPTION_TIMEOUT_MS, TRANSCRIPTION_MAX_TOTAL_MS } from './constants.js';
 import { eventBus, APP_EVENTS } from './event-bus.js';
 import { logger } from './logger.js';
 import { errorHandler } from './error-handler.js';
@@ -145,6 +145,10 @@ export class AzureAPIClient {
     }
 
     async _fetchWithRetry(uri, options, onProgress, handleResponse) {
+        // Overall deadline across all attempts and backoff sleeps. A single
+        // in-flight attempt still gets its full per-attempt timeout window; this
+        // only stops piling more attempts/sleeps past the deadline.
+        const deadline = this._now() + TRANSCRIPTION_MAX_TOTAL_MS;
         for (let attempt = 0; attempt <= MAX_TRANSCRIPTION_RETRIES; attempt++) {
             let response;
 
@@ -152,7 +156,11 @@ export class AzureAPIClient {
                 const attemptResult = await this._fetchWithTimeout(async (signal) => {
                     response = await fetch(uri, { ...options, signal });
 
-                    if (response.ok || !RETRYABLE_STATUS_CODES.has(response.status) || attempt === MAX_TRANSCRIPTION_RETRIES) {
+                    // Past the deadline, treat this attempt as final so the real
+                    // API error (e.g. the 429 message) surfaces, not a vague timeout.
+                    if (response.ok || !RETRYABLE_STATUS_CODES.has(response.status)
+                        || attempt === MAX_TRANSCRIPTION_RETRIES
+                        || this._now() >= deadline) {
                         return {
                             shouldRetry: false,
                             value: await handleResponse(response)
@@ -169,27 +177,31 @@ export class AzureAPIClient {
                 }
             } catch (error) {
                 // Only a per-attempt timeout (AbortError) is retryable here; anything
-                // else propagates. On the final attempt, surface a friendly timeout
-                // error so the caller routes the FSM to ERROR (never stuck PROCESSING).
+                // else propagates. On the final attempt or past the deadline, surface
+                // a friendly timeout error so the caller routes the FSM to ERROR
+                // (never stuck PROCESSING).
                 if (error?.name !== 'AbortError') {
                     throw error;
                 }
-                if (attempt === MAX_TRANSCRIPTION_RETRIES) {
+                if (attempt === MAX_TRANSCRIPTION_RETRIES || this._now() >= deadline) {
                     throw this._createTimeoutError();
                 }
                 const timeoutSec = Math.ceil(TRANSCRIPTION_TIMEOUT_MS / 1000);
                 await this._retryAfter(this._getRetryDelayMs(null, attempt), attempt, {
                     log: `Transcription request timed out after ${timeoutSec}s.`,
                     progress: 'Request timed out.'
-                }, onProgress);
+                }, onProgress, deadline);
                 continue;
             }
 
             await this._retryAfter(this._getRetryDelayMs(response, attempt), attempt, {
                 log: `Transient API response ${response.status}.`,
                 progress: `Azure returned ${response.status}.`
-            }, onProgress);
+            }, onProgress, deadline);
         }
+        // The loop has no other terminal return; guarantee the function never
+        // resolves undefined by throwing the friendly timeout error here.
+        throw this._createTimeoutError();
     }
 
     /**
@@ -242,9 +254,15 @@ export class AzureAPIClient {
      * @param {number} attempt - Zero-based attempt index
      * @param {{log: string, progress: string}} reason - Reason prefixes for the log + progress lines
      * @param {Function} [onProgress] - Optional progress callback
+     * @param {number} deadline - Absolute time (ms) past which no further sleep may run
      * @returns {Promise<void>}
+     * @throws {Error} Friendly timeout error if the backoff would end past the deadline
      */
-    async _retryAfter(delayMs, attempt, reason, onProgress) {
+    async _retryAfter(delayMs, attempt, reason, onProgress, deadline) {
+        // Don't start a backoff that would end past the overall deadline.
+        if (this._now() + delayMs >= deadline) {
+            throw this._createTimeoutError();
+        }
         const waitSec = Math.ceil(delayMs / 1000);
         logger.child('AzureAPIClient').warn(
             `${reason.log} Retrying in ${waitSec}s.`,
@@ -332,6 +350,17 @@ export class AzureAPIClient {
 
     _sleep(delayMs) {
         return new Promise(resolve => setTimeout(resolve, delayMs));
+    }
+
+    /**
+     * Injectable clock for deadline checks. Tests spy on this to control time
+     * deterministically, independent of fake-timer Date behavior.
+     *
+     * @private
+     * @returns {number} Current wall-clock time in milliseconds
+     */
+    _now() {
+        return Date.now();
     }
 
     _getModelAdapter(model) {

--- a/js/constants.js
+++ b/js/constants.js
@@ -344,6 +344,18 @@ export const MESSAGES = {
 export const TRANSCRIPTION_TIMEOUT_MS = 120000;
 
 /**
+ * Overall deadline for one transcription call across ALL retry attempts and
+ * backoff sleeps. A single in-flight attempt still gets its full
+ * TRANSCRIPTION_TIMEOUT_MS window; this stops further attempts/sleeps from
+ * being scheduled past the deadline, so PROCESSING can never strand the user
+ * for the multi-minute worst case (~17 min) the per-attempt timeout alone allows.
+ *
+ * @constant {number} TRANSCRIPTION_MAX_TOTAL_MS
+ * @default 180000
+ */
+export const TRANSCRIPTION_MAX_TOTAL_MS = 180000;
+
+/**
  * Recording state machine states for managing the audio recording lifecycle.
  * Defines all possible states in the recording workflow.
  * 

--- a/tests/api-client-errors.vitest.js
+++ b/tests/api-client-errors.vitest.js
@@ -619,6 +619,92 @@ describe('AzureAPIClient Error Handling', () => {
         });
     });
 
+    describe('Overall retry deadline', () => {
+        /**
+         * Scripts apiClient._now() from a fixed list of timestamps so the
+         * TRANSCRIPTION_MAX_TOTAL_MS deadline trips deterministically. _now() is
+         * called once for the deadline (loop top), then once per status check and
+         * once per sleep gate; later values exceeding the last entry reuse it.
+         */
+        function scriptNow(values) {
+            let i = 0;
+            vi.spyOn(apiClient, '_now').mockImplementation(
+                () => values[Math.min(i++, values.length - 1)]
+            );
+        }
+
+        it('surfaces the real API error when a Retry-After storm exhausts the deadline', async () => {
+            // Always-throttled response advertising a 60s Retry-After.
+            global.fetch.mockResolvedValue({
+                ok: false,
+                status: 429,
+                headers: { get: vi.fn().mockReturnValue('60') },
+                text: vi.fn().mockResolvedValue('Too many requests')
+            });
+
+            // deadline = 0 + 180000. Keep attempt 0's status check + sleep gate
+            // below it, then jump past it inside attempt 1's status check so the
+            // attempt is treated as final and the real 429 surfaces (not a timeout).
+            //   [0]=deadline base, [1]=attempt0 status, [2]=attempt0 sleep gate,
+            //   [3]=attempt1 status (>= deadline -> final)
+            scriptNow([0, 1000, 2000, 200000]);
+
+            await expect(apiClient.transcribe(new Blob())).rejects.toThrow(
+                'API rate limit reached (429). Retry after 60s.'
+            );
+
+            // Far fewer than the usual 6 attempts because the deadline cut it short.
+            expect(global.fetch).toHaveBeenCalledTimes(2);
+            expect(global.fetch.mock.calls.length).toBeLessThan(6);
+
+            const errorEmits = eventBusEmitSpy.mock.calls.filter(
+                ([event]) => event === APP_EVENTS.API_REQUEST_ERROR
+            );
+            expect(errorEmits).toHaveLength(1);
+            expect(eventBusEmitSpy).toHaveBeenCalledWith(
+                APP_EVENTS.API_REQUEST_ERROR,
+                expect.objectContaining({ status: 429 })
+            );
+        });
+
+        it('throws the friendly timeout error when a backoff would end past the deadline', async () => {
+            global.fetch.mockResolvedValue({
+                ok: false,
+                status: 503,
+                headers: { get: vi.fn().mockReturnValue('60') },
+                text: vi.fn().mockResolvedValue('Service unavailable')
+            });
+
+            // Let attempt 0's status check pass (deadline not yet reached), then
+            // trip the sleep gate: _now() + delay (60000) >= deadline (180000).
+            //   [0]=deadline base, [1]=attempt0 status (< deadline),
+            //   [2]=attempt0 sleep gate (130000 + 60000 >= 180000)
+            scriptNow([0, 1000, 130000]);
+
+            const settled = apiClient.transcribe(new Blob());
+            await expect(settled).rejects.toThrow(MESSAGES.REQUEST_TIMED_OUT);
+
+            // The thrown error preserves the friendly-timeout shape.
+            const error = await settled.catch((e) => e);
+            expect(error.apiContext.timeout).toBe(true);
+        });
+
+        it('does not clip a healthy request that resolves immediately', async () => {
+            global.fetch.mockResolvedValue({
+                ok: true,
+                status: 200,
+                headers: { get: vi.fn().mockReturnValue('application/json') },
+                json: vi.fn().mockResolvedValue({ text: 'Healthy transcription' })
+            });
+
+            // _now unscripted (real clock): elapsed ~0ms, well within the deadline.
+            const result = await apiClient.transcribe(new Blob());
+
+            expect(result).toBe('Healthy transcription');
+            expect(global.fetch).toHaveBeenCalledTimes(1);
+        });
+    });
+
     describe('Request Timeout Handling (AbortController)', () => {
         beforeEach(() => {
             vi.useFakeTimers();
@@ -683,8 +769,10 @@ describe('AzureAPIClient Error Handling', () => {
             await flushAllTimeoutAttempts();
             await assertion;
 
-            // Aborts the initial attempt plus all retries (6 total), never hanging.
-            expect(global.fetch).toHaveBeenCalledTimes(6);
+            // Under fake timers Date.now advances 120s/attempt, so the overall
+            // TRANSCRIPTION_MAX_TOTAL_MS (180s) deadline trips after 2 attempts
+            // (2 x 120s = 240s > 180s) — far short of the old 6, by design.
+            expect(global.fetch).toHaveBeenCalledTimes(2);
             // Each fetch attempt received an AbortController signal.
             expect(global.fetch.mock.calls[0][1].signal).toBeInstanceOf(AbortSignal);
 
@@ -716,8 +804,10 @@ describe('AzureAPIClient Error Handling', () => {
             await flushAllTimeoutAttempts();
             await assertion;
 
-            expect(global.fetch).toHaveBeenCalledTimes(6);
-            expect(jsonReads).toHaveLength(6);
+            // Capped at 2 attempts by the TRANSCRIPTION_MAX_TOTAL_MS deadline
+            // (120s/attempt advances Date.now past the 180s budget after the 2nd).
+            expect(global.fetch).toHaveBeenCalledTimes(2);
+            expect(jsonReads).toHaveLength(2);
             expect(jsonReads[0]).toHaveBeenCalledTimes(1);
         });
 


### PR DESCRIPTION
Implements `plans/007-bound-total-transcription-retry-time.md` (executed by a dispatched agent in an isolated worktree, reviewed against the plan's done criteria).

The per-attempt timeout exists to keep PROCESSING from stranding the user, but the aggregate across retries defeated it: a hung server meant ~12 minutes in PROCESSING (6 × 120s attempts), a Retry-After throttling storm up to ~17 minutes — with no user escape (`PROCESSING → [IDLE, ERROR]` only on settle, backoff sleeps unabortable).

- New `TRANSCRIPTION_MAX_TOTAL_MS` (180s) — an overall deadline across attempts and sleeps. One in-flight attempt still gets its full 120s window; what stops is scheduling more attempts/sleeps past the deadline.
- Past the deadline, the status path surfaces the **real API error** (e.g. the 429 message); only the sleep/timeout paths surface the friendly `REQUEST_TIMED_OUT`.
- Injectable `_now()` clock so tests script time deterministically; terminal throw after the retry loop guarantees the function can never resolve `undefined`.
- **Deliberate contract change**: under sustained per-attempt timeouts the client now stops after 2 attempts (240s > 180s budget) instead of 6 — the two affected timeout-suite count assertions were updated (behavior assertions untouched). Three new deadline tests.

Deferred by design: a user-facing cancel from PROCESSING (FSM/island design decision — see plan's maintenance notes).

Suite: 384 tests passing (+3), coverage thresholds met (api-client at 96.8% stmts), lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)