### PR TITLE
revert: remove MAI-Transcribe 1.5 style toggle; always readability-optimized (reverts #70)

### DIFF
--- a/index.html
+++ b/index.html
@@ -278,17 +278,6 @@
                 </div>
             </div>
 
-            <div id="mai-transcribe-15-settings" style="display: none;">
-                <div class="form-group">
-                    <label for="mai-transcribe-style">Transcription style</label>
-                    <select id="mai-transcribe-style">
-                        <option value="readability">Readability (cleaned up)</option>
-                        <option value="verbatim">Verbatim (keep every word)</option>
-                    </select>
-                    <small>Verbatim keeps filler words and false starts; Readability removes them. MAI-Transcribe 1.5 only.</small>
-                </div>
-            </div>
-
             <button id="save-settings" class="save-button">Save Settings</button>
         </div>
     </div>

--- a/js/constants.js
+++ b/js/constants.js
@@ -45,7 +45,6 @@ export const STORAGE_KEYS = {
   WHISPER_API_KEY:      'whisper_api_key',
   MAI_TRANSCRIBE_URI:     'mai_transcribe_uri',
   MAI_TRANSCRIBE_API_KEY: 'mai_transcribe_api_key',
-  MAI_TRANSCRIBE_STYLE:   'mai_transcribe_style',
   THEME_MODE:           'themeMode',
   RECORDING_ENVIRONMENT: 'recording_environment',
   INPUT_DEVICE:          'input_device',
@@ -63,20 +62,6 @@ export const RECORDING_ENVIRONMENTS = {
 };
 
 /**
- * MAI-Transcribe 1.5 transcription styles. READABILITY is the default and is a
- * sentinel meaning "omit transcribeStyle entirely" (preserves Microsoft's
- * readability-optimized default); only VERBATIM is ever sent on the wire.
- * @constant {Object} MAI_TRANSCRIBE_STYLES
- */
-export const MAI_TRANSCRIBE_STYLES = {
-  READABILITY: 'readability',
-  VERBATIM: 'verbatim'
-};
-
-/** @constant {string} DEFAULT_MAI_TRANSCRIBE_STYLE @default 'readability' */
-export const DEFAULT_MAI_TRANSCRIBE_STYLE = MAI_TRANSCRIBE_STYLES.READABILITY;
-
-/**
  * API parameter names for Azure Speech Services requests.
  * 
  * @constant {Object} API_PARAMS
@@ -90,8 +75,7 @@ export const API_PARAMS = {
   API_KEY_HEADER:  'api-key',
   MAI_API_KEY_HEADER: 'Ocp-Apim-Subscription-Key',
   MAI_AUDIO_FIELD:    'audio',
-  MAI_DEFINITION_FIELD: 'definition',
-  MAI_TRANSCRIBE_STYLE_FIELD: 'transcribeStyle'
+  MAI_DEFINITION_FIELD: 'definition'
 };
 
 /** API keys are sent as header values, so keep them to visible ASCII with no whitespace. */
@@ -195,7 +179,6 @@ export const ID = Object.freeze({
   CLOSE_MODAL:      'close-modal',
   WHISPER_SETTINGS: 'whisper-settings',
   MAI_TRANSCRIBE_SETTINGS: 'mai-transcribe-settings',
-  MAI_TRANSCRIBE_15_SETTINGS: 'mai-transcribe-15-settings',
 
   // Selectors / inputs
   MODEL_SELECT:     'model-select',
@@ -206,7 +189,6 @@ export const ID = Object.freeze({
   WHISPER_KEY:      'whisper-key',
   MAI_TRANSCRIBE_URI: 'mai-transcribe-uri',
   MAI_TRANSCRIBE_KEY: 'mai-transcribe-key',
-  MAI_TRANSCRIBE_STYLE: 'mai-transcribe-style',
 
   // Side panel
   SIDE_PANEL:       'side-panel',

--- a/js/model-adapters/mai-transcribe.js
+++ b/js/model-adapters/mai-transcribe.js
@@ -2,7 +2,7 @@
  * @fileoverview Model adapter for Azure MAI-Transcribe requests.
  */
 
-import { API_PARAMS, DEFAULT_WAV_FILENAME, MAI_TRANSCRIBE_STYLES, MESSAGES, MODEL_TYPES, STORAGE_KEYS } from '../constants.js';
+import { API_PARAMS, DEFAULT_WAV_FILENAME, MESSAGES, MODEL_TYPES, STORAGE_KEYS } from '../constants.js';
 import { convertToWav } from '../audio-converter.js';
 import { parseMaiTranscribeResponse } from './response-parsers.js';
 
@@ -22,16 +22,13 @@ function createMaiTranscribeModelAdapter(id, label, apiModel) {
             const formData = new FormData();
             const wavBlob = await convertToWav(audioBlob);
             formData.append(API_PARAMS.MAI_AUDIO_FIELD, wavBlob, DEFAULT_WAV_FILENAME);
-            const enhancedMode = {
-                enabled: true,
-                model: apiModel,
-                task: 'transcribe'
-            };
-            if (apiModel === MODEL_TYPES.MAI_TRANSCRIBE_1_5_API_MODEL
-                && config.transcribeStyle === MAI_TRANSCRIBE_STYLES.VERBATIM) {
-                enhancedMode[API_PARAMS.MAI_TRANSCRIBE_STYLE_FIELD] = MAI_TRANSCRIBE_STYLES.VERBATIM;
-            }
-            formData.append(API_PARAMS.MAI_DEFINITION_FIELD, JSON.stringify({ enhancedMode }));
+            formData.append(API_PARAMS.MAI_DEFINITION_FIELD, JSON.stringify({
+                enhancedMode: {
+                    enabled: true,
+                    model: apiModel,
+                    task: 'transcribe'
+                }
+            }));
 
             return {
                 headers: { [API_PARAMS.MAI_API_KEY_HEADER]: config.apiKey },

--- a/js/settings.js
+++ b/js/settings.js
@@ -2,7 +2,7 @@
  * @fileoverview Settings management for API configuration and user preferences.
  */
 
-import { STORAGE_KEYS, MESSAGES, ID, MODEL_TYPES, RECORDING_ENVIRONMENTS, API_KEY_VALUE_PATTERN, DEFAULT_MAI_TRANSCRIBE_STYLE } from './constants.js';
+import { STORAGE_KEYS, MESSAGES, ID, MODEL_TYPES, RECORDING_ENVIRONMENTS, API_KEY_VALUE_PATTERN } from './constants.js';
 import { PermissionManager } from './permission-manager.js';
 import { eventBus, APP_EVENTS } from './event-bus.js';
 import { logger } from './logger.js';
@@ -50,8 +50,6 @@ export class Settings {
     this.maiTranscribeSettings = document.getElementById(ID.MAI_TRANSCRIBE_SETTINGS);
     this.maiTranscribeUriInput = document.getElementById(ID.MAI_TRANSCRIBE_URI);
     this.maiTranscribeKeyInput = document.getElementById(ID.MAI_TRANSCRIBE_KEY);
-    this.maiTranscribe15Settings = document.getElementById(ID.MAI_TRANSCRIBE_15_SETTINGS);
-    this.maiTranscribeStyleSelect = document.getElementById(ID.MAI_TRANSCRIBE_STYLE);
     this.recordingEnvironmentSelect = document.getElementById(ID.RECORDING_ENVIRONMENT);
 
         // Side panel elements
@@ -421,10 +419,6 @@ export class Settings {
         if (this.maiTranscribeSettings) {
             this.maiTranscribeSettings.style.display = isMai ? 'block' : 'none';
         }
-        if (this.maiTranscribe15Settings) {
-            this.maiTranscribe15Settings.style.display =
-                currentModel === MODEL_TYPES.MAI_TRANSCRIBE_1_5 ? 'block' : 'none';
-        }
     }
     
     /**
@@ -490,11 +484,6 @@ export class Settings {
         const savedEnv = localStorage.getItem(STORAGE_KEYS.RECORDING_ENVIRONMENT) || RECORDING_ENVIRONMENTS.QUIET;
         if (this.recordingEnvironmentSelect) {
             this.recordingEnvironmentSelect.value = savedEnv;
-        }
-
-        const savedStyle = localStorage.getItem(STORAGE_KEYS.MAI_TRANSCRIBE_STYLE) || DEFAULT_MAI_TRANSCRIBE_STYLE;
-        if (this.maiTranscribeStyleSelect) {
-            this.maiTranscribeStyleSelect.value = savedStyle;
         }
     }
 
@@ -626,10 +615,6 @@ export class Settings {
             localStorage.setItem(STORAGE_KEYS.RECORDING_ENVIRONMENT, this.recordingEnvironmentSelect.value);
         }
 
-        if (this.maiTranscribeStyleSelect) {
-            localStorage.setItem(STORAGE_KEYS.MAI_TRANSCRIBE_STYLE, this.maiTranscribeStyleSelect.value);
-        }
-
         this.closeSettingsModal();
 
         eventBus.emit(APP_EVENTS.UI_STATUS_UPDATE, {
@@ -697,15 +682,11 @@ export class Settings {
     getModelConfig() {
         const model = this.getCurrentModel();
         const isMai = this._isMaiModel(model);
-        const config = {
+        return {
             model,
             apiKey: localStorage.getItem(isMai ? STORAGE_KEYS.MAI_TRANSCRIBE_API_KEY : STORAGE_KEYS.WHISPER_API_KEY),
             uri: localStorage.getItem(isMai ? STORAGE_KEYS.MAI_TRANSCRIBE_URI : STORAGE_KEYS.WHISPER_URI)
         };
-        if (model === MODEL_TYPES.MAI_TRANSCRIBE_1_5) {
-            config.transcribeStyle = localStorage.getItem(STORAGE_KEYS.MAI_TRANSCRIBE_STYLE) || DEFAULT_MAI_TRANSCRIBE_STYLE;
-        }
-        return config;
     }
 
     _isMaiModel(model) {

--- a/tests/model-adapters.vitest.js
+++ b/tests/model-adapters.vitest.js
@@ -8,7 +8,6 @@ import {
     DEFAULT_FILENAME,
     DEFAULT_LANGUAGE,
     DEFAULT_WAV_FILENAME,
-    MAI_TRANSCRIBE_STYLES,
     MESSAGES,
     MODEL_TYPES
 } from '../js/constants.js';
@@ -301,105 +300,5 @@ describe('AzureAPIClient model adapter registry', () => {
         expect(convertToWav).toHaveBeenCalledWith(audioBlob);
         expect(onProgress).toHaveBeenCalledWith(MESSAGES.CONVERTING_AUDIO);
         expect(onProgress).toHaveBeenCalledWith(MESSAGES.SENDING_TO_MAI_TRANSCRIBE);
-    });
-
-    it('includes transcribeStyle on MAI-Transcribe 1.5 when style is verbatim', async () => {
-        const settings = createSettings(MODEL_TYPES.MAI_TRANSCRIBE_1_5, {
-            transcribeStyle: MAI_TRANSCRIBE_STYLES.VERBATIM
-        });
-        const apiClient = new AzureAPIClient(settings);
-        const audioBlob = new Blob(['audio']);
-        mockJsonResponse({
-            combinedPhrases: [{ text: 'MAI 1.5 verbatim segment.' }],
-            phrases: []
-        });
-
-        await apiClient.transcribe(audioBlob);
-
-        expect(JSON.parse(getFormEntry(API_PARAMS.MAI_DEFINITION_FIELD).value)).toEqual({
-            enhancedMode: {
-                enabled: true,
-                model: MODEL_TYPES.MAI_TRANSCRIBE_1_5_API_MODEL,
-                task: 'transcribe',
-                [API_PARAMS.MAI_TRANSCRIBE_STYLE_FIELD]: MAI_TRANSCRIBE_STYLES.VERBATIM
-            }
-        });
-    });
-
-    it('omits transcribeStyle on MAI-Transcribe 1.5 when style is readability', async () => {
-        const settings = createSettings(MODEL_TYPES.MAI_TRANSCRIBE_1_5, {
-            transcribeStyle: MAI_TRANSCRIBE_STYLES.READABILITY
-        });
-        const apiClient = new AzureAPIClient(settings);
-        const audioBlob = new Blob(['audio']);
-        mockJsonResponse({
-            combinedPhrases: [{ text: 'MAI 1.5 readability segment.' }],
-            phrases: []
-        });
-
-        await apiClient.transcribe(audioBlob);
-
-        expect(JSON.parse(getFormEntry(API_PARAMS.MAI_DEFINITION_FIELD).value)).toEqual({
-            enhancedMode: {
-                enabled: true,
-                model: MODEL_TYPES.MAI_TRANSCRIBE_1_5_API_MODEL,
-                task: 'transcribe'
-            }
-        });
-    });
-
-    it('omits transcribeStyle on MAI-Transcribe 1.5 when no style is provided', async () => {
-        const settings = createSettings(MODEL_TYPES.MAI_TRANSCRIBE_1_5);
-        const apiClient = new AzureAPIClient(settings);
-        const audioBlob = new Blob(['audio']);
-        mockJsonResponse({
-            combinedPhrases: [{ text: 'MAI 1.5 default segment.' }],
-            phrases: []
-        });
-
-        await apiClient.transcribe(audioBlob);
-
-        expect(JSON.parse(getFormEntry(API_PARAMS.MAI_DEFINITION_FIELD).value)).toEqual({
-            enhancedMode: {
-                enabled: true,
-                model: MODEL_TYPES.MAI_TRANSCRIBE_1_5_API_MODEL,
-                task: 'transcribe'
-            }
-        });
-    });
-
-    it('omits transcribeStyle on MAI-Transcribe 1.0 even when style is verbatim', async () => {
-        const settings = createSettings(MODEL_TYPES.MAI_TRANSCRIBE, {
-            transcribeStyle: MAI_TRANSCRIBE_STYLES.VERBATIM
-        });
-        const apiClient = new AzureAPIClient(settings);
-        const audioBlob = new Blob(['audio']);
-        mockJsonResponse({
-            combinedPhrases: [{ text: 'MAI 1.0 segment.' }],
-            phrases: []
-        });
-
-        await apiClient.transcribe(audioBlob);
-
-        expect(JSON.parse(getFormEntry(API_PARAMS.MAI_DEFINITION_FIELD).value)).toEqual({
-            enhancedMode: {
-                enabled: true,
-                model: MODEL_TYPES.MAI_TRANSCRIBE_API_MODEL,
-                task: 'transcribe'
-            }
-        });
-    });
-
-    it('builds no MAI definition for Whisper even when style is verbatim', async () => {
-        const settings = createSettings(MODEL_TYPES.WHISPER, {
-            transcribeStyle: MAI_TRANSCRIBE_STYLES.VERBATIM
-        });
-        const apiClient = new AzureAPIClient(settings);
-        const audioBlob = new Blob(['audio']);
-        mockTextResponse(' Whisper text ');
-
-        await apiClient.transcribe(audioBlob);
-
-        expect(getFormEntry(API_PARAMS.MAI_DEFINITION_FIELD)).toBeUndefined();
     });
 });

--- a/tests/settings-persistence.vitest.js
+++ b/tests/settings-persistence.vitest.js
@@ -6,7 +6,7 @@
 import { vi } from 'vitest';
 import { eventBus, APP_EVENTS } from '../js/event-bus.js';
 import { generateMockApiKeyForValidation } from './helpers/mock-api-keys.js';
-import { STORAGE_KEYS, MESSAGES, ID, MODEL_TYPES, RECORDING_ENVIRONMENTS, DEFAULT_MAI_TRANSCRIBE_STYLE } from '../js/constants.js';
+import { STORAGE_KEYS, MESSAGES, ID, MODEL_TYPES, RECORDING_ENVIRONMENTS } from '../js/constants.js';
 import { applyDomSpies } from './helpers/test-dom-vitest.js';
 import { createLocalStorageMock } from './helpers/mock-settings-dom.js';
 
@@ -135,24 +135,6 @@ describe('Settings Persistence & Save Workflow', () => {
             freshSettings.openSettingsModal();
 
             expect(document.getElementById(ID.RECORDING_ENVIRONMENT).value).toBe(RECORDING_ENVIRONMENTS.NOISY);
-
-            freshSettings.destroy();
-        });
-
-        test('should load the saved MAI-Transcribe 1.5 style into the form on modal open', () => {
-            localStorageMock.getItem.mockImplementation((key) => {
-                if (key === STORAGE_KEYS.MODEL) return MODEL_TYPES.MAI_TRANSCRIBE_1_5;
-                if (key === STORAGE_KEYS.MAI_TRANSCRIBE_STYLE) return 'verbatim';
-                return null;
-            });
-
-            const freshSettings = new Settings();
-            vi.spyOn(freshSettings, 'checkInitialSettings').mockImplementation(() => {});
-            vi.spyOn(freshSettings, 'updateSettingsVisibility').mockImplementation(() => {});
-
-            freshSettings.openSettingsModal();
-
-            expect(freshSettings.maiTranscribeStyleSelect.value).toBe('verbatim');
 
             freshSettings.destroy();
         });
@@ -294,7 +276,6 @@ describe('Settings Persistence & Save Workflow', () => {
                 model: MODEL_TYPES.MAI_TRANSCRIBE_1_5,
                 apiKey: maiApiKey,
                 uri: maiApiUri,
-                transcribeStyle: DEFAULT_MAI_TRANSCRIBE_STYLE,
             });
 
             freshSettings.destroy();
@@ -376,20 +357,6 @@ describe('Settings Persistence & Save Workflow', () => {
                     hasApiKey: true
                 })
             );
-        });
-
-        test('should persist the MAI-Transcribe 1.5 verbatim style on save', () => {
-            const maiApiKey = 'speech-resource-key-for-mai-15';
-            const maiApiUri = 'https://mai-transcribe.cognitiveservices.azure.com/speechtotext/transcriptions:transcribe?api-version=2025-10-15';
-            document.getElementById(ID.SETTINGS_MODEL_SELECT).value = MODEL_TYPES.MAI_TRANSCRIBE_1_5;
-            document.getElementById(ID.MAI_TRANSCRIBE_URI).value = maiApiUri;
-            document.getElementById(ID.MAI_TRANSCRIBE_KEY).value = maiApiKey;
-            document.getElementById(ID.MAI_TRANSCRIBE_STYLE).value = 'verbatim';
-            document.getElementById(ID.SETTINGS_MODAL).style.display = 'block';
-
-            settings.saveSettings();
-
-            expect(localStorageMock.setItem).toHaveBeenCalledWith(STORAGE_KEYS.MAI_TRANSCRIBE_STYLE, 'verbatim');
         });
     });
 

--- a/tests/settings-unit.vitest.js
+++ b/tests/settings-unit.vitest.js
@@ -127,8 +127,6 @@ describe('Settings Helper Methods - Isolated Unit Tests', () => {
         mockElements[ID.STATUS] = createMockElement();
         mockElements[ID.WHISPER_SETTINGS] = createMockElement();
         mockElements[ID.MAI_TRANSCRIBE_SETTINGS] = createMockElement();
-        mockElements[ID.MAI_TRANSCRIBE_15_SETTINGS] = createMockElement();
-        mockElements[ID.MAI_TRANSCRIBE_STYLE] = createMockElement();
 
         // Mock URL constructor with realistic behavior
         global.URL.mockImplementation((url) => {
@@ -742,22 +740,6 @@ describe('Settings Helper Methods - Isolated Unit Tests', () => {
                 expect(isValid).toBe(true);
             });
 
-        });
-    });
-
-    describe('updateSettingsVisibility Method', () => {
-        it('reveals the MAI-Transcribe 1.5 style container only for the 1.5 model', () => {
-            mockModelSelect.value = 'whisper';
-            settings.updateSettingsVisibility();
-            expect(settings.maiTranscribe15Settings.style.display).toBe('none');
-
-            mockModelSelect.value = MODEL_TYPES.MAI_TRANSCRIBE;
-            settings.updateSettingsVisibility();
-            expect(settings.maiTranscribe15Settings.style.display).toBe('none');
-
-            mockModelSelect.value = MODEL_TYPES.MAI_TRANSCRIBE_1_5;
-            settings.updateSettingsVisibility();
-            expect(settings.maiTranscribe15Settings.style.display).toBe('block');
         });
     });
 


### PR DESCRIPTION
Implements `plans/009-revert-mai-style-toggle.md`. Reverts PR #70 (plan 008) per the user's decision to **only ever use readability-optimized** transcription, with no toggle.

**Why a revert is the right change:** readability-optimized is Microsoft's *field-absent* default — there is no `"transcribeStyle":"readability"` value to send; omitting the field IS readability. The app omitted it before plan 008, so every MAI-Transcribe 1.5 request was already readability-optimized. Plan 008 only added the *verbatim* escape hatch. Removing it returns the app to its original, always-readability behavior — no new code needed.

Clean `git revert -m 1` of the #70 merge: the 7 files are byte-identical to the pre-008 commit (verified `git diff aa3b28c` is empty), zero toggle remnants, and MAI 1.5 now sends exactly `{"enhancedMode":{"enabled":true,"model":"mai-transcribe-1.5","task":"transcribe"}}`. Whisper / whisper-translate / MAI 1.0 were never affected.

Suite back to **384 tests** passing, lint clean, coverage thresholds met. Plan 008 stays documented and is re-runnable if verbatim is ever wanted again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)