### PR TITLE
test: add real-browser transcription smoke test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,3 +35,34 @@ jobs:
 
       - name: Size budget
         run: npm run size
+
+  browser-smoke:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Install Chromium
+        run: npx playwright install --with-deps --no-shell chromium
+
+      - name: Browser smoke test
+        run: npm run test:browser
+
+      - name: Upload Playwright report
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: browser-smoke-artifacts
+          path: |
+            playwright-report/
+            test-results/
+          if-no-files-found: ignore
+          retention-days: 7

--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,9 @@ node_modules/
 # Generated documentation and coverage files
 coverage/
 docs/
+playwright-report/
+test-results/
+tests/browser/.artifacts/
 
 # But allow coverage baseline in metrics
 !metrics/

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "MIT",
       "devDependencies": {
         "@eslint/js": "^9.30.1",
+        "@playwright/test": "^1.61.1",
         "@size-limit/file": "^11.2.0",
         "@vitest/coverage-v8": "^3.2.4",
         "eslint": "^9.30.1",
@@ -1096,6 +1097,22 @@
       "optional": true,
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.61.1.tgz",
+      "integrity": "sha512-8nKv6+0RJSL9FE4jYOEGXnPeM/Hg12qZpmqzZjRh3qM0Y7c3z1mrOTfFLids72RDQYVh9WpLEfR5WdpNX4fkig==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.61.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
@@ -3296,6 +3313,53 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.61.1.tgz",
+      "integrity": "sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.61.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.1.tgz",
+      "integrity": "sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/postcss": {

--- a/package.json
+++ b/package.json
@@ -12,6 +12,8 @@
     "test": "vitest run",
     "test:watch": "vitest --watch",
     "test:coverage": "vitest run --coverage",
+    "test:browser": "playwright test",
+    "test:browser:headed": "playwright test --headed",
     "prepare": "husky",
     "lint": "eslint \"js/**/*.js\"",
     "lint:fix": "eslint --fix \"js/**/*.js\"",
@@ -21,6 +23,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.30.1",
+    "@playwright/test": "^1.61.1",
     "@size-limit/file": "^11.2.0",
     "@vitest/coverage-v8": "^3.2.4",
     "eslint": "^9.30.1",

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -1,0 +1,46 @@
+import { defineConfig } from '@playwright/test';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+
+const repoRoot = path.dirname(fileURLToPath(import.meta.url));
+const fixture = path.join(repoRoot, 'tests/browser/.artifacts/fake-microphone.wav');
+
+export default defineConfig({
+    testDir: 'tests/browser',
+    globalSetup: './tests/browser/global-setup.mjs',
+    workers: 1,
+    fullyParallel: false,
+    retries: 0,
+    timeout: 45_000,
+    expect: { timeout: 10_000 },
+    reporter: process.env.CI
+        ? [['line'], ['html', { open: 'never' }]]
+        : 'list',
+    use: {
+        baseURL: 'http://127.0.0.1:4173',
+        permissions: ['microphone'],
+        ignoreHTTPSErrors: true,
+        serviceWorkers: 'block',
+        trace: 'retain-on-failure',
+        screenshot: 'only-on-failure',
+        video: 'off'
+    },
+    webServer: {
+        command: 'node tests/browser/static-server.mjs',
+        url: 'http://127.0.0.1:4173/',
+        reuseExistingServer: false,
+        timeout: 15_000
+    },
+    projects: [{
+        name: 'chromium',
+        use: {
+            channel: 'chromium',
+            launchOptions: {
+                args: [
+                    '--use-fake-device-for-media-stream',
+                    `--use-file-for-fake-audio-capture=${fixture}`
+                ]
+            }
+        }
+    }]
+});

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -27,7 +27,7 @@ export default defineConfig({
     },
     webServer: {
         command: 'node tests/browser/static-server.mjs',
-        url: 'http://127.0.0.1:4173/',
+        url: 'http://[::1]:4175/',
         reuseExistingServer: false,
         timeout: 15_000
     },

--- a/tests/browser/global-setup.mjs
+++ b/tests/browser/global-setup.mjs
@@ -1,0 +1,51 @@
+/**
+ * @fileoverview Generates deterministic browser-test audio artifacts.
+ */
+
+import { mkdirSync, writeFileSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const artifactsDirectory = path.join(
+    path.dirname(fileURLToPath(import.meta.url)),
+    '.artifacts'
+);
+const fixturePath = path.join(artifactsDirectory, 'fake-microphone.wav');
+
+export default async function globalSetup() {
+    const sampleRate = 48_000;
+    const durationSeconds = 3;
+    const sampleCount = sampleRate * durationSeconds;
+    const bytesPerSample = 2;
+    const dataSize = sampleCount * bytesPerSample;
+    const buffer = new ArrayBuffer(44 + dataSize);
+    const view = new DataView(buffer);
+
+    writeAscii(view, 0, 'RIFF');
+    view.setUint32(4, 36 + dataSize, true);
+    writeAscii(view, 8, 'WAVE');
+    writeAscii(view, 12, 'fmt ');
+    view.setUint32(16, 16, true);
+    view.setUint16(20, 1, true);
+    view.setUint16(22, 1, true);
+    view.setUint32(24, sampleRate, true);
+    view.setUint32(28, sampleRate * bytesPerSample, true);
+    view.setUint16(32, bytesPerSample, true);
+    view.setUint16(34, 16, true);
+    writeAscii(view, 36, 'data');
+    view.setUint32(40, dataSize, true);
+
+    for (let index = 0; index < sampleCount; index++) {
+        const sample = Math.sin(2 * Math.PI * 440 * index / sampleRate) * 0.3;
+        view.setInt16(44 + index * bytesPerSample, sample * 0x7FFF, true);
+    }
+
+    mkdirSync(artifactsDirectory, { recursive: true });
+    writeFileSync(fixturePath, Buffer.from(buffer));
+}
+
+function writeAscii(view, offset, value) {
+    for (let index = 0; index < value.length; index++) {
+        view.setUint8(offset + index, value.charCodeAt(index));
+    }
+}

--- a/tests/browser/static-server.mjs
+++ b/tests/browser/static-server.mjs
@@ -149,6 +149,11 @@ const apiServer = https.createServer(createCertificate(), (request, response) =>
     });
 });
 
+const readinessServer = http.createServer((_request, response) => {
+    response.writeHead(204, { Connection: 'close' });
+    response.end();
+});
+
 function createCertificate() {
     mkdirSync(artifactsDirectory, { recursive: true });
     if (!existsSync(keyPath) || !existsSync(certificatePath)) {
@@ -164,14 +169,19 @@ function createCertificate() {
 
 appServer.listen(4173, '127.0.0.1', () => {
     apiServer.listen(4174, '127.0.0.1', () => {
-        console.log('Browser test servers listening on 127.0.0.1:4173 and 127.0.0.1:4174');
+        readinessServer.listen(4175, '::1', () => {
+            console.log('Browser test servers listening on 127.0.0.1:4173, 127.0.0.1:4174, and [::1]:4175');
+        });
     });
 });
 
 function shutdown() {
+    readinessServer.closeAllConnections();
     apiServer.closeAllConnections();
     appServer.closeAllConnections();
-    apiServer.close(() => appServer.close(() => process.exit(0)));
+    readinessServer.close(() => {
+        apiServer.close(() => appServer.close(() => process.exit(0)));
+    });
 }
 
 process.on('SIGINT', shutdown);

--- a/tests/browser/static-server.mjs
+++ b/tests/browser/static-server.mjs
@@ -1,0 +1,178 @@
+/**
+ * @fileoverview Static app server and local HTTPS transcription stub.
+ */
+
+import { execFileSync } from 'node:child_process';
+import { existsSync, mkdirSync, readFileSync, statSync } from 'node:fs';
+import http from 'node:http';
+import https from 'node:https';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..');
+const artifactsDirectory = path.join(repoRoot, 'tests/browser/.artifacts');
+const keyPath = path.join(artifactsDirectory, 'localhost-key.pem');
+const certificatePath = path.join(artifactsDirectory, 'localhost-cert.pem');
+const transcriptionPath = '/speechtotext/transcriptions:transcribe';
+const allowedOrigin = 'http://127.0.0.1:4173';
+const maxPostBytes = 5 * 1024 * 1024;
+
+let apiObservations = freshObservations();
+
+function freshObservations() {
+    return {
+        optionsCount: 0,
+        postCount: 0,
+        preflightHeaders: {},
+        postHeaders: {},
+        postBodyBase64: '',
+        captureError: null
+    };
+}
+
+function sendJson(response, status, value) {
+    response.writeHead(status, {
+        'Cache-Control': 'no-store',
+        'Content-Type': 'application/json'
+    });
+    response.end(JSON.stringify(value));
+}
+
+const appServer = http.createServer((request, response) => {
+    const requestUrl = new URL(request.url, allowedOrigin);
+
+    if (request.method === 'POST' && requestUrl.pathname === '/__browser-test__/reset') {
+        apiObservations = freshObservations();
+        sendJson(response, 200, { ok: true });
+        return;
+    }
+    if (request.method === 'GET' && requestUrl.pathname === '/__browser-test__/api-observations') {
+        sendJson(response, 200, apiObservations);
+        return;
+    }
+    if (request.method === 'GET' && requestUrl.pathname === '/favicon.ico') {
+        response.writeHead(204, { 'Cache-Control': 'no-store' });
+        response.end();
+        return;
+    }
+
+    const pathname = requestUrl.pathname === '/' ? '/index.html' : requestUrl.pathname;
+    const decodedPath = decodeURIComponent(pathname);
+    const filePath = path.resolve(repoRoot, `.${decodedPath}`);
+    const relativePath = path.relative(repoRoot, filePath);
+    if (relativePath.startsWith('..') || path.isAbsolute(relativePath)
+        || !existsSync(filePath) || !statSync(filePath).isFile()) {
+        response.writeHead(404, { 'Cache-Control': 'no-store' });
+        response.end('Not found');
+        return;
+    }
+
+    const mimeTypes = {
+        '.html': 'text/html',
+        '.js': 'text/javascript',
+        '.mjs': 'text/javascript',
+        '.css': 'text/css',
+        '.json': 'application/json',
+        '.svg': 'image/svg+xml',
+        '.png': 'image/png',
+        '.ico': 'image/x-icon'
+    };
+    response.writeHead(200, {
+        'Cache-Control': 'no-store',
+        'Content-Type': mimeTypes[path.extname(filePath)] ?? 'application/octet-stream'
+    });
+    response.end(readFileSync(filePath));
+});
+
+function corsHeaders() {
+    return {
+        'Access-Control-Allow-Headers': 'Ocp-Apim-Subscription-Key',
+        'Access-Control-Allow-Methods': 'POST',
+        'Access-Control-Allow-Origin': allowedOrigin
+    };
+}
+
+const apiServer = https.createServer(createCertificate(), (request, response) => {
+    const requestUrl = new URL(request.url, 'https://127.0.0.1:4174');
+    if (requestUrl.pathname !== transcriptionPath) {
+        response.writeHead(404);
+        response.end('Not found');
+        return;
+    }
+
+    if (request.method === 'OPTIONS') {
+        apiObservations.optionsCount += 1;
+        apiObservations.preflightHeaders = { ...request.headers };
+        response.writeHead(204, corsHeaders());
+        response.end();
+        return;
+    }
+
+    if (request.method !== 'POST') {
+        response.writeHead(404);
+        response.end('Not found');
+        return;
+    }
+
+    apiObservations.postCount += 1;
+    apiObservations.postHeaders = { ...request.headers };
+    const chunks = [];
+    let byteCount = 0;
+    let exceededLimit = false;
+    request.on('data', chunk => {
+        byteCount += chunk.length;
+        if (byteCount > maxPostBytes) {
+            exceededLimit = true;
+            apiObservations.captureError = `POST exceeded ${maxPostBytes} bytes (${byteCount} received)`;
+            return;
+        }
+        chunks.push(chunk);
+    });
+    request.on('end', () => {
+        if (exceededLimit) {
+            response.writeHead(413, corsHeaders());
+            response.end('Payload too large');
+            return;
+        }
+        apiObservations.postBodyBase64 = Buffer.concat(chunks).toString('base64');
+        response.writeHead(200, {
+            ...corsHeaders(),
+            'Content-Type': 'application/json'
+        });
+        response.end(JSON.stringify({
+            combinedPhrases: [{ text: 'Browser smoke transcript' }],
+            phrases: []
+        }));
+    });
+    request.on('error', error => {
+        apiObservations.captureError = error.message;
+    });
+});
+
+function createCertificate() {
+    mkdirSync(artifactsDirectory, { recursive: true });
+    if (!existsSync(keyPath) || !existsSync(certificatePath)) {
+        execFileSync('/usr/bin/openssl', [
+            'req', '-x509', '-newkey', 'rsa:2048', '-nodes',
+            '-keyout', keyPath, '-out', certificatePath,
+            '-days', '1', '-subj', '/CN=127.0.0.1',
+            '-addext', 'subjectAltName=IP:127.0.0.1'
+        ], { stdio: 'ignore' });
+    }
+    return { key: readFileSync(keyPath), cert: readFileSync(certificatePath) };
+}
+
+appServer.listen(4173, '127.0.0.1', () => {
+    apiServer.listen(4174, '127.0.0.1', () => {
+        console.log('Browser test servers listening on 127.0.0.1:4173 and 127.0.0.1:4174');
+    });
+});
+
+function shutdown() {
+    apiServer.closeAllConnections();
+    appServer.closeAllConnections();
+    apiServer.close(() => appServer.close(() => process.exit(0)));
+}
+
+process.on('SIGINT', shutdown);
+process.on('SIGTERM', shutdown);

--- a/tests/browser/transcription-smoke.spec.js
+++ b/tests/browser/transcription-smoke.spec.js
@@ -1,0 +1,147 @@
+/**
+ * @fileoverview Real-browser transcription smoke test from capture to reload.
+ */
+
+import { expect, test } from '@playwright/test';
+
+const appOrigin = 'http://127.0.0.1:4173';
+const endpoint = 'https://127.0.0.1:4174/speechtotext/transcriptions:transcribe?api-version=2025-10-15';
+const observationsUrl = `${appOrigin}/__browser-test__/api-observations`;
+
+test('records, converts, transcribes, and restores a transcript', async ({ page }) => {
+    await page.addInitScript(({ transcriptionEndpoint }) => {
+        localStorage.setItem('transcription_model', 'mai-transcribe-1.5');
+        localStorage.setItem('mai_transcribe_uri', transcriptionEndpoint);
+        localStorage.setItem('mai_transcribe_api_key', 'e2e-test-key');
+        localStorage.setItem('recording_environment', 'quiet');
+    }, { transcriptionEndpoint: endpoint });
+
+    const resetResponse = await fetch(`${appOrigin}/__browser-test__/reset`, { method: 'POST' });
+    expect(resetResponse.ok).toBe(true);
+
+    await page.route('https://fonts.googleapis.com/**', route => route.fulfill({
+        status: 200,
+        contentType: 'text/css',
+        body: ''
+    }));
+
+    const pageErrors = [];
+    const consoleErrors = [];
+    const workerStates = new Map();
+    page.on('pageerror', error => pageErrors.push(error.message));
+    page.on('console', message => {
+        if (message.type() === 'error') {
+            consoleErrors.push(message.text());
+        }
+    });
+    page.on('worker', worker => {
+        const state = { closed: false };
+        workerStates.set(worker, state);
+        worker.on('close', () => {
+            state.closed = true;
+        });
+    });
+
+    await page.goto('/');
+    const primary = page.locator('#primary-action');
+    const transcript = page.locator('#transcript');
+    await expect(primary).toBeEnabled();
+    await expect(primary).toContainText('Start recording');
+    await expect(transcript).toHaveValue('');
+    await page.unroute('https://fonts.googleapis.com/**');
+
+    await primary.click();
+    await expect(primary).toContainText('Done');
+    await expect(primary).toBeEnabled();
+    await page.waitForTimeout(1_200);
+
+    const workerPromise = page.waitForEvent('worker', {
+        predicate: worker => worker.url().endsWith('/js/audio-converter.worker.js')
+    });
+    const postPromise = page.waitForRequest(request =>
+        request.url() === endpoint && request.method() === 'POST'
+    );
+    await primary.click();
+    const [worker, request] = await Promise.all([workerPromise, postPromise]);
+
+    expect(worker.url()).toMatch(/\/js\/audio-converter\.worker\.js$/);
+    expect(workerStates.get(worker)?.closed).toBe(false);
+    expect(await worker.evaluate(() => self.location.pathname))
+        .toBe('/js/audio-converter.worker.js');
+
+    await expect(transcript).toHaveValue('Browser smoke transcript');
+    await expect(primary).toContainText('Start recording');
+    await expect(primary).toBeEnabled();
+
+    expect(request.method()).toBe('POST');
+    expect(request.url()).toBe(endpoint);
+    expect(request.headers()['ocp-apim-subscription-key']).toBe('e2e-test-key');
+    expect(request.headers()['content-type']).toMatch(/^multipart\/form-data;\s*boundary=/);
+
+    const observations = await fetchObservations();
+    expect(observations.captureError).toBeNull();
+    expect(observations.optionsCount).toBe(1);
+    expect(observations.postCount).toBe(1);
+    expect(observations.preflightHeaders['access-control-request-method']).toBe('POST');
+    expect(observations.preflightHeaders['access-control-request-headers'])
+        .toContain('ocp-apim-subscription-key');
+    expect(observations.postHeaders['ocp-apim-subscription-key']).toBe('e2e-test-key');
+    expect(observations.postHeaders['content-type']).toMatch(/^multipart\/form-data;\s*boundary=/);
+    expect(observations.postBodyBase64).not.toBe('');
+
+    const body = Buffer.from(observations.postBodyBase64, 'base64');
+    const form = await new Response(body, {
+        headers: { 'content-type': observations.postHeaders['content-type'] }
+    }).formData();
+    expect(JSON.parse(form.get('definition'))).toEqual({
+        enhancedMode: {
+            enabled: true,
+            model: 'mai-transcribe-1.5',
+            task: 'transcribe'
+        }
+    });
+
+    const audio = form.get('audio');
+    expect(audio.name).toBe('recording.wav');
+    expect(audio.type).toBe('audio/wav');
+    const wav = new Uint8Array(await audio.arrayBuffer());
+    const wavView = new DataView(wav.buffer, wav.byteOffset, wav.byteLength);
+    expect(wav.byteLength).toBeGreaterThan(44);
+    expect(readAscii(wav, 0, 4)).toBe('RIFF');
+    expect(readAscii(wav, 8, 4)).toBe('WAVE');
+    expect(readAscii(wav, 36, 4)).toBe('data');
+    expect(wavView.getUint16(22, true)).toBe(1);
+    expect(wavView.getUint32(24, true)).toBe(16_000);
+    expect(wavView.getUint16(34, true)).toBe(16);
+    expect(wavView.getUint32(40, true)).toBeGreaterThan(0);
+    const samplesToInspect = Math.min(16_000, (wav.byteLength - 44) / 2);
+    expect(Array.from({ length: samplesToInspect }, (_, index) =>
+        wavView.getInt16(44 + index * 2, true)
+    ).some(sample => sample !== 0)).toBe(true);
+
+    const storedTranscript = JSON.parse(await page.evaluate(() =>
+        localStorage.getItem('transcript_record')
+    ));
+    expect(storedTranscript.text).toBe('Browser smoke transcript');
+    expect(storedTranscript.savedAt).toEqual(expect.any(Number));
+
+    await page.reload();
+    await expect(primary).toBeEnabled();
+    await expect(primary).toContainText('Start recording');
+    await expect(transcript).toHaveValue('Browser smoke transcript');
+    const observationsAfterReload = await fetchObservations();
+    expect(observationsAfterReload.optionsCount).toBe(1);
+    expect(observationsAfterReload.postCount).toBe(1);
+    expect(pageErrors).toEqual([]);
+    expect(consoleErrors).toEqual([]);
+});
+
+async function fetchObservations() {
+    const response = await fetch(observationsUrl);
+    expect(response.ok).toBe(true);
+    return response.json();
+}
+
+function readAscii(bytes, offset, length) {
+    return String.fromCharCode(...bytes.slice(offset, offset + length));
+}


### PR DESCRIPTION
## Summary

- add one deterministic Chromium Playwright smoke test for the real recording-to-transcript path
- exercise native `MediaRecorder`, `OfflineAudioContext`, the real conversion worker, multipart WAV generation, transcript rendering, and reload persistence
- use Chromium fake microphone capture and a local HTTPS Azure stub that observes genuine CORS preflight and captures the multipart request server-side
- add a separate browser-smoke CI job with failure artifacts
- stabilize immediate repeated runs under WSL mirrored networking with a dedicated IPv6 readiness listener

## Why

The Happy DOM suite validates component contracts but cannot detect failures across the production page, browser media APIs, module worker, native multipart request, DOM, and browser persistence. This closes that integration gap without live Azure credentials, cost, or a human speaker.

## Validation

- `npm run test:browser && npm run test:browser` — passed twice consecutively
- `npm run test:coverage` — 393 tests passed; 92.69% statements
- `npm run lint`
- `npm run deps:check`
- `npm run deps:check:prod`
- `npm run size` — 43.33 kB brotlied
- CI workflow YAML parse, diff hygiene, file scope, and full diff review passed

## Scope

No production JavaScript or HTML changed. The PR adds browser-test scaffolding, the smoke specification, Playwright configuration/dependency, ignore rules, and its CI job.
