### PR TITLE
chore(ui): remove retired control plumbing

### DIFF
--- a/js/constants.js
+++ b/js/constants.js
@@ -141,9 +141,6 @@ export const CONTENT_TYPES = {
  * 
  * @constant {Object} ID
  * @readonly
- * @property {string} MIC_BUTTON - Main microphone recording button
- * @property {string} PAUSE_BUTTON - Pause recording button
- * @property {string} CANCEL_BUTTON - Cancel recording button
  * @property {string} SETTINGS_BUTTON - Open settings modal button
  * @property {string} GRAB_TEXT_BUTTON - Copy transcription text button
  * @property {string} SAVE_SETTINGS - Save settings button
@@ -157,9 +154,6 @@ export const CONTENT_TYPES = {
  */
 export const ID = Object.freeze({
   // Buttons
-  MIC_BUTTON:       'mic-button',
-  PAUSE_BUTTON:     'pause-button',
-  CANCEL_BUTTON:    'cancel-button',
   SETTINGS_BUTTON:  'settings-button',
   GRAB_TEXT_BUTTON: 'grab-text-button',
   RESTORE_BUTTON:   'restore-button',
@@ -191,7 +185,6 @@ export const ID = Object.freeze({
   // Selectors / inputs
   MODEL_SELECT:     'model-select',
   SETTINGS_MODEL_SELECT: 'settings-model-select',
-  THEME_MODE:       'theme-mode',
   RECORDING_ENVIRONMENT: 'recording-environment',
   WHISPER_URI:      'whisper-uri',
   WHISPER_KEY:      'whisper-key',
@@ -210,8 +203,6 @@ export const ID = Object.freeze({
   VISUALIZER:       'visualizer',
 
   // Icons
-  PAUSE_ICON:       'pause-icon',
-  PLAY_ICON:        'play-icon',
   MOON_ICON:        'moon-icon',
   SUN_ICON:         'sun-icon',
 

--- a/js/event-bus.js
+++ b/js/event-bus.js
@@ -223,7 +223,6 @@ export const eventBus = new EventBus();
  * @property {string} SETTINGS_VALIDATION_ERROR - Emitted when settings validation fails
  * 
  * @property {string} APP_INITIALIZED - Emitted when application initialization completes
- * @property {string} APP_ERROR - Emitted when application encounters critical error
  * @property {string} APP_PREREQUISITES_CHECKED - Emitted when initial checks complete
  * @property {string} APP_READY - Emitted when application is ready for user interaction
  * 

--- a/js/ui.js
+++ b/js/ui.js
@@ -49,11 +49,7 @@ export class UI {
         this.discardConfirmButton = document.getElementById(ID.DISCARD_CONFIRM);
 
         // Settings / theme
-        this.settingsButton = document.getElementById(ID.SETTINGS_BUTTON);
         this.themeToggle = document.getElementById(ID.THEME_TOGGLE);
-        this.settingsModal = document.getElementById(ID.SETTINGS_MODAL);
-        this.closeModalButton = document.getElementById(ID.CLOSE_MODAL);
-        this.saveSettingsButton = document.getElementById(ID.SAVE_SETTINGS);
         this.moonIcon = document.getElementById(ID.MOON_ICON);
         this.sunIcon = document.getElementById(ID.SUN_ICON);
 

--- a/tests/settings-workflow.vitest.js
+++ b/tests/settings-workflow.vitest.js
@@ -43,9 +43,8 @@ const requiredElementIds = [
     ID.MODEL_SELECT, ID.SETTINGS_MODEL_SELECT, ID.SETTINGS_MODAL, ID.CLOSE_MODAL,
     ID.SAVE_SETTINGS, ID.SETTINGS_BUTTON, ID.STATUS, ID.WHISPER_SETTINGS,
     ID.MAI_TRANSCRIBE_SETTINGS, ID.WHISPER_URI, ID.WHISPER_KEY, ID.MAI_TRANSCRIBE_URI, ID.MAI_TRANSCRIBE_KEY,
-    ID.MIC_BUTTON, ID.THEME_TOGGLE, ID.PAUSE_BUTTON, ID.CANCEL_BUTTON, ID.GRAB_TEXT_BUTTON,
-    ID.TRANSCRIPT, ID.TIMER, ID.SPINNER_CONTAINER, ID.PAUSE_ICON,
-    ID.PLAY_ICON, ID.MOON_ICON, ID.SUN_ICON, ID.THEME_MODE
+    ID.THEME_TOGGLE, ID.GRAB_TEXT_BUTTON, ID.TRANSCRIPT, ID.TIMER,
+    ID.SPINNER_CONTAINER, ID.MOON_ICON, ID.SUN_ICON
 ];
 
 requiredElementIds.forEach(id => {
@@ -345,7 +344,6 @@ describe('Settings Save Workflow Issues - Issue #32', () => {
 
         // Set initial modal state for workflow tests
         mockElements.get(ID.SETTINGS_MODAL).style.display = 'block';
-        mockElements.get(ID.MIC_BUTTON).disabled = true;
 
         settings = new Settings();
         ui = new UI();
@@ -529,15 +527,11 @@ describe('Settings Save Workflow Issues - Issue #32', () => {
 describe('Microphone Activation Issue Analysis', () => {
     let settings;
     let ui;
-    let micButton;
 
     beforeEach(() => {
         vi.clearAllMocks();
         localStorageMock.getItem.mockReturnValue('whisper');
         resetMockElements();
-
-        micButton = mockElements.get(ID.MIC_BUTTON);
-        micButton.disabled = true;
 
         settings = new Settings();
         ui = new UI();


### PR DESCRIPTION
## Summary

- remove six retired legacy DOM ID constants and their stale test fixtures
- remove four UI constructor queries for settings controls owned by `Settings`
- remove the orphaned `APP_ERROR` documentation entry

## Why

These names and cached elements no longer participate in the current Dynamic Island control flow. Keeping them made tests manufacture DOM that production no longer uses and obscured ownership between `UI` and `Settings`.

## Validation

- rebased cleanly onto current `main`
- 393 Vitest tests passed with coverage thresholds
- deterministic Chromium browser smoke passed
- lint, dependency checks, and size budget passed
- bundle size: 43.19 kB brotlied
- focused four-file diff independently reviewed

No behavior or public interface changes are intended.
