### PR TITLE
fix: make transcript autosave failure-aware

### DIFF
--- a/js/constants.js
+++ b/js/constants.js
@@ -256,6 +256,7 @@ export const DEFAULT_RESET_STATUS =
  * @property {string} RECORDING_IN_PROGRESS - Status during active recording
  * @property {string} PROCESSING_AUDIO - Status during transcription processing
  * @property {string} TRANSCRIPTION_COMPLETE - Success message after transcription
+ * @property {string} TRANSCRIPT_AUTOSAVE_FAILED - Warning when transcript persistence fails
  * @property {string} SETTINGS_SAVED - Confirmation when settings are saved
  * @property {string} ERROR_PREFIX - Prefix for error messages
  */
@@ -306,6 +307,7 @@ export const MESSAGES = {
   
   // Transcription
   TRANSCRIPTION_COMPLETE: 'Transcription complete',
+  TRANSCRIPT_AUTOSAVE_FAILED: 'Autosave is unavailable. Copy your transcript before leaving.',
   
   // Clipboard Operations
   TEXT_GRAB_SUCCESS: 'Grabbed to clipboard',

--- a/js/transcript-store.js
+++ b/js/transcript-store.js
@@ -36,19 +36,20 @@ export class TranscriptStore {
      * clears the slot (there is nothing to recover).
      *
      * @param {string} text
-     * @returns {void}
+     * @returns {boolean} True when the transcript was persisted or cleared.
      */
     save(text) {
-        if (!this.storage) return;
+        if (!this.storage) return false;
         const value = typeof text === 'string' ? text : '';
         if (!value) {
-            this.clear();
-            return;
+            return this.clear();
         }
         try {
             this.storage.setItem(this.key, JSON.stringify({ text: value, savedAt: Date.now() }));
+            return true;
         } catch (error) {
             logger.child('TranscriptStore').debug('Failed to persist transcript:', error);
+            return false;
         }
     }
 
@@ -76,14 +77,16 @@ export class TranscriptStore {
     /**
      * Remove the recovery slot.
      *
-     * @returns {void}
+     * @returns {boolean} True when the recovery slot was removed.
      */
     clear() {
-        if (!this.storage) return;
+        if (!this.storage) return false;
         try {
             this.storage.removeItem(this.key);
+            return true;
         } catch {
             /* storage unavailable — nothing to clear */
+            return false;
         }
     }
 

--- a/js/ui.js
+++ b/js/ui.js
@@ -62,6 +62,15 @@ export class UI {
         this.currentState = RECORDING_STATES.IDLE;
         this.ready = false;
         this.canRetry = false;
+        this._autosaveTimer = null;
+        this._autosaveFailureNotified = false;
+        this._pagehideRegistered = false;
+        this._pagehideHandler = () => {
+            if (this._autosaveTimer === null) return;
+            clearTimeout(this._autosaveTimer);
+            this._autosaveTimer = null;
+            this.persistTranscript();
+        };
     }
 
     /**
@@ -155,11 +164,16 @@ export class UI {
         }
 
         // Autosave in-place edits (debounced) so a crash/reload never loses words.
+        if (!this._pagehideRegistered && typeof window !== 'undefined' && typeof window.addEventListener === 'function') {
+            window.addEventListener('pagehide', this._pagehideHandler);
+            this._pagehideRegistered = true;
+        }
         if (this.transcriptElement) {
             this.transcriptElement.addEventListener('input', () => {
                 this.updateRestoreAffordance();
                 clearTimeout(this._autosaveTimer);
                 this._autosaveTimer = setTimeout(() => {
+                    this._autosaveTimer = null;
                     this.persistTranscript();
                     this.updateRestoreAffordance();
                 }, 500);
@@ -784,12 +798,22 @@ export class UI {
      * later swaps localStorage for a backend). Empty text clears the recovery slot.
      *
      * @method persistTranscript
-     * @returns {void}
+     * @returns {boolean} True when the transcript store reports success.
      */
     persistTranscript() {
-        if (this.transcriptStore && this.transcriptElement) {
-            this.transcriptStore.save(this.transcriptElement.value);
+        if (!this.transcriptStore || !this.transcriptElement) return false;
+
+        const persisted = this.transcriptStore.save(this.transcriptElement.value);
+        if (persisted) {
+            this._autosaveFailureNotified = false;
+            return true;
         }
+
+        if (!this._autosaveFailureNotified) {
+            this._autosaveFailureNotified = true;
+            this._emitStatus(MESSAGES.TRANSCRIPT_AUTOSAVE_FAILED, 'error');
+        }
+        return false;
     }
 
     /**
@@ -838,9 +862,13 @@ export class UI {
             this._emitStatus(MESSAGES.NO_TEXT_TO_GRAB, 'error');
             return Promise.resolve(false);
         }
-        this.persistTranscript();
+        const persisted = this.persistTranscript();
         return navigator.clipboard.writeText(text)
             .then(() => {
+                if (!persisted) {
+                    this.updateRestoreAffordance();
+                    return true;
+                }
                 clearTimeout(this._autosaveTimer);
                 this._autosaveTimer = null;
                 this.transcriptElement.value = '';

--- a/tests/transcript-actions.vitest.js
+++ b/tests/transcript-actions.vitest.js
@@ -25,7 +25,7 @@ vi.mock('../js/status-helper.js', () => ({ showTemporaryStatus: vi.fn() }));
 
 const { UI } = await import('../js/ui.js');
 const { TranscriptStore } = await import('../js/transcript-store.js');
-const { TRANSCRIPT_SEGMENT_DIVIDER } = await import('../js/constants.js');
+const { TRANSCRIPT_SEGMENT_DIVIDER, MESSAGES } = await import('../js/constants.js');
 
 function makeStorage(initial = {}) {
     const data = { ...initial };
@@ -80,6 +80,25 @@ describe('Transcript actions: Grab / Restore / append', () => {
             expect(ok).toBe(false);
             expect(ui.transcriptElement.value).toBe('precious'); // not lost from the box
             expect(store.load()?.text).toBe('precious');         // and saved as a record
+        });
+
+        it('keeps the text visible when persistence fails but clipboard succeeds', async () => {
+            const storage = {
+                getItem: vi.fn().mockReturnValue(null),
+                setItem: vi.fn(() => { throw new Error('quota exceeded'); }),
+                removeItem: vi.fn()
+            };
+            ui.transcriptStore = new TranscriptStore(storage, 'tk');
+            ui.transcriptElement.value = 'not safely saved';
+            const statusSpy = vi.spyOn(ui, '_emitStatus');
+
+            const ok = await ui.grabTranscript();
+
+            expect(ok).toBe(true);
+            expect(writeText).toHaveBeenCalledWith('not safely saved');
+            expect(ui.transcriptElement.value).toBe('not safely saved');
+            expect(ui.restoreButton.hidden).toBe(true);
+            expect(statusSpy).toHaveBeenCalledWith(MESSAGES.TRANSCRIPT_AUTOSAVE_FAILED, 'error');
         });
 
         it('cancels a pending empty autosave when Grab clears the box', async () => {

--- a/tests/transcript-autosave.vitest.js
+++ b/tests/transcript-autosave.vitest.js
@@ -24,7 +24,9 @@ global.localStorage = {
 };
 
 global.window = {
-    matchMedia: vi.fn(() => ({ matches: false, addEventListener: vi.fn() }))
+    matchMedia: vi.fn(() => ({ matches: false, addEventListener: vi.fn() })),
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn()
 };
 
 vi.mock('../js/status-helper.js', () => ({
@@ -32,6 +34,7 @@ vi.mock('../js/status-helper.js', () => ({
 }));
 
 const { eventBus, APP_EVENTS } = await import('../js/event-bus.js');
+const { MESSAGES } = await import('../js/constants.js');
 const { UI } = await import('../js/ui.js');
 const { TranscriptStore } = await import('../js/transcript-store.js');
 
@@ -92,6 +95,90 @@ describe('Transcript autosave + restore wiring', () => {
         ui.transcriptStore = null;
         expect(() => ui.persistTranscript()).not.toThrow();
         expect(() => ui.restoreTranscriptIfEmpty()).not.toThrow();
+    });
+
+    it('warns once per failed save streak and warns again after recovery', () => {
+        let rejectWrites = true;
+        const storage = {
+            getItem: vi.fn().mockReturnValue(null),
+            setItem: vi.fn(() => {
+                if (rejectWrites) throw new Error('quota exceeded');
+            }),
+            removeItem: vi.fn()
+        };
+        ui.transcriptStore = new TranscriptStore(storage, 'tk');
+        ui.transcriptElement.value = 'unsaved text';
+        const statusSpy = vi.spyOn(ui, '_emitStatus');
+
+        expect(ui.persistTranscript()).toBe(false);
+        expect(ui.persistTranscript()).toBe(false);
+        expect(statusSpy).toHaveBeenCalledTimes(1);
+        expect(statusSpy).toHaveBeenCalledWith(MESSAGES.TRANSCRIPT_AUTOSAVE_FAILED, 'error');
+
+        rejectWrites = false;
+        expect(ui.persistTranscript()).toBe(true);
+
+        rejectWrites = true;
+        expect(ui.persistTranscript()).toBe(false);
+        expect(statusSpy).toHaveBeenCalledTimes(2);
+    });
+
+    it('warns on a failed empty clear without changing Restore state', () => {
+        const storage = {
+            getItem: vi.fn().mockReturnValue(JSON.stringify({ text: 'recoverable', savedAt: Date.now() })),
+            setItem: vi.fn(),
+            removeItem: vi.fn(() => { throw new Error('storage unavailable'); })
+        };
+        ui.transcriptStore = new TranscriptStore(storage, 'tk');
+        ui.transcriptElement.value = '';
+        ui.updateRestoreAffordance();
+        const statusSpy = vi.spyOn(ui, '_emitStatus');
+
+        expect(ui.persistTranscript()).toBe(false);
+        ui.updateRestoreAffordance();
+
+        expect(ui.transcriptElement.value).toBe('');
+        expect(ui.restoreButton.hidden).toBe(false);
+        expect(statusSpy).toHaveBeenCalledWith(MESSAGES.TRANSCRIPT_AUTOSAVE_FAILED, 'error');
+    });
+
+    it('flushes the latest pending edit once on pagehide', () => {
+        vi.useFakeTimers();
+        try {
+            ui.setupEventListeners();
+            const inputListener = ui.transcriptElement.addEventListener.mock.calls
+                .find(([eventName]) => eventName === 'input');
+            const inputHandler = inputListener?.[1];
+            const pagehideListener = window.addEventListener.mock.calls
+                .find(([eventName]) => eventName === 'pagehide');
+            const pagehideHandler = pagehideListener?.[1];
+            const saveSpy = vi.spyOn(store, 'save');
+
+            expect(pagehideHandler).toEqual(expect.any(Function));
+            ui.transcriptElement.value = 'latest before navigation';
+            inputHandler();
+            pagehideHandler();
+
+            expect(store.load()?.text).toBe('latest before navigation');
+            expect(saveSpy).toHaveBeenCalledTimes(1);
+
+            vi.advanceTimersByTime(500);
+            expect(saveSpy).toHaveBeenCalledTimes(1);
+        } finally {
+            vi.useRealTimers();
+        }
+    });
+
+    it('registers the pagehide handler only once across repeated init calls', () => {
+        vi.spyOn(ui, 'loadTheme').mockImplementation(() => {});
+        vi.spyOn(ui, 'checkRecordingPrerequisites').mockReturnValue(false);
+        const settings = { checkInitialSettings: vi.fn() };
+
+        ui.init(settings, store);
+        ui.init(settings, store);
+
+        expect(window.addEventListener).toHaveBeenCalledTimes(1);
+        expect(window.addEventListener).toHaveBeenCalledWith('pagehide', expect.any(Function));
     });
 
     it('debounces input autosave to the latest transcript', () => {

--- a/tests/transcript-store.vitest.js
+++ b/tests/transcript-store.vitest.js
@@ -15,7 +15,7 @@ function makeStorage(initial = {}) {
 describe('TranscriptStore', () => {
     it('saves and loads a transcript round-trip', () => {
         const store = new TranscriptStore(makeStorage(), 'k');
-        store.save('hello world');
+        expect(store.save('hello world')).toBe(true);
         expect(store.load().text).toBe('hello world');
         expect(store.has()).toBe(true);
     });
@@ -23,7 +23,7 @@ describe('TranscriptStore', () => {
     it('treats an empty string as a clear (nothing to recover)', () => {
         const store = new TranscriptStore(makeStorage(), 'k');
         store.save('something');
-        store.save('');
+        expect(store.save('')).toBe(true);
         expect(store.load()).toBeNull();
         expect(store.has()).toBe(false);
     });
@@ -31,7 +31,7 @@ describe('TranscriptStore', () => {
     it('clear() removes the slot', () => {
         const store = new TranscriptStore(makeStorage(), 'k');
         store.save('x');
-        store.clear();
+        expect(store.clear()).toBe(true);
         expect(store.has()).toBe(false);
     });
 
@@ -57,7 +57,8 @@ describe('TranscriptStore', () => {
 
     it('degrades gracefully with no storage backend (explicit null)', () => {
         const store = new TranscriptStore(null, 'k');
-        expect(() => store.save('x')).not.toThrow();
+        expect(store.save('x')).toBe(false);
+        expect(store.clear()).toBe(false);
         expect(store.load()).toBeNull();
         expect(store.has()).toBe(false);
     });
@@ -66,7 +67,7 @@ describe('TranscriptStore', () => {
         const setItem = vi.fn(() => { throw new Error('quota exceeded'); });
         const store = new TranscriptStore({ setItem }, 'transcript-key');
 
-        expect(() => store.save('valuable transcript')).not.toThrow();
+        expect(store.save('valuable transcript')).toBe(false);
 
         expect(setItem).toHaveBeenCalledTimes(1);
         expect(setItem).toHaveBeenCalledWith('transcript-key', expect.any(String));
@@ -74,5 +75,13 @@ describe('TranscriptStore', () => {
             text: 'valuable transcript',
             savedAt: expect.any(Number)
         });
+    });
+
+    it('degrades gracefully when storage rejects a clear', () => {
+        const removeItem = vi.fn(() => { throw new Error('storage unavailable'); });
+        const store = new TranscriptStore({ removeItem }, 'transcript-key');
+
+        expect(store.clear()).toBe(false);
+        expect(removeItem).toHaveBeenCalledWith('transcript-key');
     });
 });


### PR DESCRIPTION
## What changed

- Make transcript save and clear operations report success or failure.
- Warn once per autosave failure streak and flush pending edits on pagehide.
- Preserve visible text when Grab copies successfully but persistence fails.
- Add focused regression coverage for storage failures, navigation flushing, and Grab safety.

## Why

The final 500 ms of typing could be lost during navigation, while localStorage failures were silently ignored and Grab could imply an unavailable recovery record existed.

## Validation

- 351 Vitest tests passed across 31 files.
- Coverage thresholds passed: 93.25% statements.
- Playwright Chromium smoke passed.
- ESLint, Knip development/production checks, Size Limit, and diff checks passed.
