### PR TITLE
fix: recover from recorder lifecycle failures

### DIFF
--- a/js/audio-handler.js
+++ b/js/audio-handler.js
@@ -39,6 +39,8 @@ export class AudioHandler {
         this.timerInterval = null;
         this.currentTimerDisplay = TIMER_CONFIG.DEFAULT_DISPLAY;
         this.pendingRetryBlob = null;
+        this.activeStream = null;
+        this._activeRecordingSession = null;
 
         this.permissionManager = new PermissionManager();
         
@@ -133,16 +135,19 @@ export class AudioHandler {
                 await this.stateMachine.transitionTo(RECORDING_STATES.IDLE);
                 return;
             }
-            
-            // Transition to recording
+
+            // Keep the FSM in INITIALIZING until MediaRecorder.start() succeeds.
+            const session = this.startRecording(stream);
+
+            // Commit the recording only after the recorder has started.
             await this.stateMachine.transitionTo(RECORDING_STATES.RECORDING);
-            this.startRecording(stream);
+            this.startVisualization(session);
+            this.recordingStartTime = Date.now();
+            this.startTimer();
             
         } catch (err) {
             errorHandler.handleError(err, { module: 'AudioHandler' });
-            const errorMessage = err?.message || err?.toString() || 'Unknown error';
-            // handleErrorState emits UI_STATUS_UPDATE with prefix + retry hint
-            await this.stateMachine.transitionTo(RECORDING_STATES.ERROR, { error: errorMessage });
+            await this.recoverFromRecorderError(err);
             // Config errors are handled by validateConfig() which emits
             // API_CONFIG_MISSING before throwing — the event listener opens settings
         }
@@ -156,17 +161,23 @@ export class AudioHandler {
      * @returns {Promise<void>} Resolves when recorder has been stopped or an error event has been emitted
      */
     async stopRecordingFlow() {
-        await this.stateMachine.transitionTo(RECORDING_STATES.STOPPING);
+        const transitioned = await this.stateMachine.transitionTo(RECORDING_STATES.STOPPING);
+        if (!transitioned) return;
 
-    // Stop the timer immediately when stopping
-    clearInterval(this.timerInterval);
-    // Emit timer reset event immediately for UI
-    eventBus.emit(APP_EVENTS.UI_TIMER_RESET);
+        const session = this._activeRecordingSession;
+        this.markVisualizationStopped(session);
+
+        // Stop the timer immediately when stopping
+        clearInterval(this.timerInterval);
+        this.timerInterval = null;
+        // Emit timer reset event immediately for UI
+        eventBus.emit(APP_EVENTS.UI_TIMER_RESET);
 
         try {
             this.safeStopRecorder();
         } catch (err) {
-            eventBus.emit(APP_EVENTS.RECORDING_ERROR, { error: err.message });
+            errorHandler.handleError(err, { module: 'AudioHandler' });
+            await this.recoverFromRecorderError(err, session);
         }
     }
     
@@ -175,58 +186,186 @@ export class AudioHandler {
      * 
      * @method startRecording
      * @param {MediaStream} stream - Audio media stream from microphone
-     * @returns {void}
+     * @returns {Object} The active recording session
      */
     startRecording(stream) {
+        const session = {
+            stream,
+            recorder: null,
+            visualizationStarted: false,
+            visualizationStopped: false,
+            failureHandled: false,
+            stopEventHandled: false
+        };
+
         this.audioChunks = [];
-        this.mediaRecorder = new MediaRecorder(stream);
+        this.activeStream = stream;
+        this._activeRecordingSession = session;
 
-        // Emit event to start visualization (UI determines canvas + theme)
-        eventBus.emit(APP_EVENTS.VISUALIZATION_START, { stream });
+        const recorder = new MediaRecorder(stream);
+        session.recorder = recorder;
+        this.mediaRecorder = recorder;
 
-        this.mediaRecorder.addEventListener('dataavailable', event => {
+        recorder.addEventListener('dataavailable', event => {
+            if (session.failureHandled || session.stopEventHandled) return;
             this.audioChunks.push(event.data);
         });
 
-        this.mediaRecorder.addEventListener('stop', async () => {
-            // Emit event to stop visualization
-            eventBus.emit(APP_EVENTS.VISUALIZATION_STOP);
-
-            if (this.stateMachine.getState() === RECORDING_STATES.CANCELLING) {
-                stream.getTracks().forEach(t => t.stop());
-                await this.stateMachine.transitionTo(RECORDING_STATES.IDLE);
-                this.cleanup();
-                return;
-            }
-
-            // Transition to processing
-            await this.stateMachine.transitionTo(RECORDING_STATES.PROCESSING);
-            await this.processAndSendAudio(stream);
-
-            // Cleanup after audio has been processed so chunks remain intact
-            this.cleanup();
+        recorder.addEventListener('stop', async () => {
+            await this.handleRecorderStop(session);
         });
 
-        this.mediaRecorder.start(250);
-        this.recordingStartTime = Date.now();
-        // Start timer
-        this.startTimer();
+        recorder.addEventListener('error', async event => {
+            const error = event?.error instanceof Error
+                ? event.error
+                : new Error(event?.message || 'MediaRecorder error');
+            await this.recoverFromRecorderError(error, session);
+        });
+
+        recorder.start(250);
+        return session;
+    }
+
+    /**
+     * Starts visualization only after MediaRecorder startup has committed.
+     *
+     * @method startVisualization
+     * @param {Object} session - Active recording session
+     * @returns {void}
+     */
+    startVisualization(session) {
+        if (!session || session.failureHandled) return;
+
+        session.visualizationStarted = true;
+        eventBus.emit(APP_EVENTS.VISUALIZATION_START, { stream: session.stream });
+    }
+
+    /**
+     * Stops visualization once for a recording session.
+     *
+     * @method stopVisualization
+     * @param {Object} session - Active recording session
+     * @returns {void}
+     */
+    stopVisualization(session) {
+        if (!session?.visualizationStarted || session.visualizationStopped) return;
+
+        session.visualizationStopped = true;
+        eventBus.emit(APP_EVENTS.VISUALIZATION_STOP);
+    }
+
+    /**
+     * Marks visualization as stopped when the state machine already emitted
+     * the visualization stop event while entering STOPPING.
+     *
+     * @method markVisualizationStopped
+     * @param {Object} session - Active recording session
+     * @returns {void}
+     */
+    markVisualizationStopped(session) {
+        if (session?.visualizationStarted) {
+            session.visualizationStopped = true;
+        }
+    }
+
+    /**
+     * Handles the recorder stop event exactly once.
+     *
+     * @async
+     * @method handleRecorderStop
+     * @param {Object} session - Active recording session
+     * @returns {Promise<void>}
+     */
+    async handleRecorderStop(session) {
+        if (session.failureHandled || session.stopEventHandled) return;
+        session.stopEventHandled = true;
+
+        this.stopVisualization(session);
+
+        if (this.stateMachine.getState() === RECORDING_STATES.CANCELLING) {
+            this.stopStreamTracks(session.stream);
+            await this.stateMachine.transitionTo(RECORDING_STATES.IDLE);
+            this.cleanup();
+            return;
+        }
+
+        if (this.stateMachine.getState() !== RECORDING_STATES.STOPPING) return;
+
+        // Transition to processing
+        await this.stateMachine.transitionTo(RECORDING_STATES.PROCESSING);
+        await this.processAndSendAudio(session.stream);
+
+        // Cleanup after audio has been processed so chunks remain intact
+        this.cleanup();
     }
 
     /**
      * Safely stops the MediaRecorder if active and handles any stop errors.
      * 
      * @method safeStopRecorder
-     * @returns {void}
+     * @returns {boolean} True when stop was requested
      */
     safeStopRecorder() {
-        if (this.mediaRecorder && this.mediaRecorder.state !== 'inactive') {
-            try {
-                this.mediaRecorder.stop();
-            } catch (err) {
-                eventBus.emit(APP_EVENTS.RECORDING_ERROR, { error: err.message });
-            }
+        if (!this.mediaRecorder || this.mediaRecorder.state === 'inactive') return false;
+
+        this.mediaRecorder.stop();
+        return true;
+    }
+
+    /**
+     * Recovers from a recorder lifecycle failure and leaves the FSM in ERROR
+     * whenever the current state has a legal error transition.
+     *
+     * @async
+     * @method recoverFromRecorderError
+     * @param {Error} error - Recorder lifecycle error
+     * @param {Object} [session=this._activeRecordingSession] - Failed session
+     * @returns {Promise<void>}
+     */
+    async recoverFromRecorderError(error, session = this._activeRecordingSession) {
+        if (session?.failureHandled) return;
+        if (session) session.failureHandled = true;
+
+        const currentState = this.stateMachine.getState();
+        if (currentState === RECORDING_STATES.RECORDING
+            || currentState === RECORDING_STATES.PAUSED) {
+            const transitioned = await this.stateMachine.transitionTo(RECORDING_STATES.STOPPING);
+            if (transitioned) this.markVisualizationStopped(session);
         }
+
+        this.stopVisualization(session);
+        this.stopStreamTracks(session?.stream || this.activeStream);
+        this.cleanup();
+
+        const errorMessage = error?.message || error?.toString() || 'Unknown error';
+        let recoveryState = this.stateMachine.getState();
+        if (recoveryState === RECORDING_STATES.CONFIRMING_DISCARD) {
+            await this.stateMachine.transitionTo(RECORDING_STATES.CANCELLING);
+            recoveryState = RECORDING_STATES.CANCELLING;
+        }
+        if (recoveryState === RECORDING_STATES.CANCELLING) {
+            await this.stateMachine.transitionTo(RECORDING_STATES.IDLE);
+        }
+        if (this.stateMachine.canTransitionTo(RECORDING_STATES.ERROR)) {
+            await this.stateMachine.transitionTo(RECORDING_STATES.ERROR, { error: errorMessage });
+        }
+    }
+
+    /**
+     * Stops every track in a media stream, even when one track rejects stop().
+     *
+     * @method stopStreamTracks
+     * @param {MediaStream|null} stream - Stream whose tracks should stop
+     * @returns {void}
+     */
+    stopStreamTracks(stream) {
+        stream?.getTracks?.().forEach(track => {
+            try {
+                track.stop();
+            } catch {
+                // A failed track stop must not prevent cleanup of other tracks.
+            }
+        });
     }
 
     /**
@@ -374,7 +513,7 @@ export class AudioHandler {
         this.pendingRetryBlob = audioBlob;
 
         const result = await this.sendToAzureAPI(audioBlob);
-        stream.getTracks().forEach(track => track.stop());
+        this.stopStreamTracks(stream);
         this.audioChunks.length = 0;
 
         if (result.success) {
@@ -477,6 +616,8 @@ export class AudioHandler {
         this.audioChunks.length = 0;
         this.recordingStartTime = null;
         this.mediaRecorder = null;
+        this.activeStream = null;
+        this._activeRecordingSession = null;
     }
 
     /**

--- a/plans/README.md
+++ b/plans/README.md
@@ -46,7 +46,7 @@ and update your row when done.
 | 018 | Add targeted behavior coverage after test consolidation | P2 | S/M | 016 + 017 | DONE (merged via PR #87 as `dff0b8c`, 2026-07-12; implementation `385bacf`) |
 | 019 | Make adapter metadata authoritative for credential storage | P2 | M | — | DONE (implemented as `8db9d8d`, independently approved, and merged in PR #89 as `7930363`) |
 | 020 | Make transcript autosave observable and navigation-safe | P1 | S/M | — | DONE (implemented as `0e9a092`, independently approved, and merged via PR #91 as `a01298a`, 2026-07-13) |
-| 021 | Recover atomically from MediaRecorder lifecycle failures | P1 | M | — | TODO |
+| 021 | Recover atomically from MediaRecorder lifecycle failures | P1 | M | — | DONE (implemented and independently approved as `b490280` on `fix/021-mediarecorder-lifecycle-recovery`; awaiting operator merge) |
 | 022 | Keep unsaved settings-model changes draft-only | P1 | S | — | TODO |
 | 023 | Preserve the browser-selected recording container | P2 | M | 021 | TODO |
 | 024 | Enforce model-specific audio upload limits before network submission | P2 | M | 021 + 023 | TODO |

--- a/tests/audio-handler-integration.vitest.js
+++ b/tests/audio-handler-integration.vitest.js
@@ -66,6 +66,8 @@ describe('AudioHandler Integration', () => {
   let eventBusEmitSpy;
   let mockMediaRecorder;
   let mediaRecorderEventHandlers;
+  let mockStream;
+  let trackStopSpy;
   
   beforeEach(() => {
     vi.clearAllMocks();
@@ -98,11 +100,12 @@ describe('AudioHandler Integration', () => {
     global.MediaRecorder = vi.fn(() => mockMediaRecorder);
     
     // Mock stream
-    const mockStream = {
+    trackStopSpy = vi.fn();
+    mockStream = {
       getAudioTracks: vi.fn(() => [{ kind: 'audio' }]),
       getTracks: vi.fn(() => [{
         kind: 'audio',
-        stop: vi.fn(),
+        stop: trackStopSpy,
         readyState: 'live'
       }])
     };
@@ -139,6 +142,39 @@ describe('AudioHandler Integration', () => {
     // Spy on event bus emissions
     eventBusEmitSpy = vi.spyOn(eventBus, 'emit');
   });
+
+  const expectRecorderFailureRecovery = (startedVisualization = true) => {
+    const visualizationStarts = eventBusEmitSpy.mock.calls.filter(
+      ([event]) => event === APP_EVENTS.VISUALIZATION_START
+    );
+    const visualizationStops = eventBusEmitSpy.mock.calls.filter(
+      ([event]) => event === APP_EVENTS.VISUALIZATION_STOP
+    );
+    const errorTransitions = eventBusEmitSpy.mock.calls.filter(
+      ([event, data]) => event === APP_EVENTS.RECORDING_STATE_CHANGED
+        && data?.newState === RECORDING_STATES.ERROR
+    );
+    const recordingTransitions = eventBusEmitSpy.mock.calls.filter(
+      ([event, data]) => event === APP_EVENTS.RECORDING_STATE_CHANGED
+        && data?.newState === RECORDING_STATES.RECORDING
+    );
+
+    expect(trackStopSpy).toHaveBeenCalledTimes(1);
+    expect(audioHandler.timerInterval).toBeNull();
+    expect(audioHandler.audioChunks).toHaveLength(0);
+    expect(audioHandler.recordingStartTime).toBeNull();
+    expect(audioHandler.mediaRecorder).toBeNull();
+    expect(audioHandler.activeStream).toBeNull();
+    expect(audioHandler._activeRecordingSession).toBeNull();
+    expect(audioHandler.stateMachine.getState()).toBe(RECORDING_STATES.ERROR);
+    expect(errorTransitions).toHaveLength(1);
+    expect(eventBusEmitSpy.mock.calls.filter(
+      ([event]) => event === APP_EVENTS.RECORDING_ERROR
+    )).toHaveLength(1);
+    expect(visualizationStarts).toHaveLength(startedVisualization ? 1 : 0);
+    expect(visualizationStops).toHaveLength(startedVisualization ? 1 : 0);
+    expect(recordingTransitions).toHaveLength(startedVisualization ? 1 : 0);
+  };
   
   afterEach(() => {
     // Restore original mediaDevices API
@@ -180,31 +216,44 @@ describe('AudioHandler Integration', () => {
       }).not.toThrow();
     });
     
-    it('handles MediaRecorder errors gracefully', async () => {
-      // Start recording
+    it('recovers when MediaRecorder construction throws', async () => {
+      global.MediaRecorder.mockImplementationOnce(() => {
+        throw new Error('MediaRecorder constructor failed');
+      });
+
       await audioHandler.startRecordingFlow();
-      
-      // Force mediaRecorder to active state
-      mockMediaRecorder.state = 'recording';
-      
-      // Make stop method throw error
+
+      expectRecorderFailureRecovery(false);
+    });
+
+    it('recovers when MediaRecorder.start() throws', async () => {
+      mockMediaRecorder.start.mockImplementationOnce(() => {
+        throw new Error('MediaRecorder.start() failed');
+      });
+
+      await audioHandler.startRecordingFlow();
+
+      expectRecorderFailureRecovery(false);
+    });
+
+    it.each(['recording', 'paused'])('recovers when MediaRecorder.stop() throws from %s state', async (state) => {
+      await audioHandler.startRecordingFlow();
+
+      if (state === 'paused') {
+        await audioHandler.togglePause();
+      }
+
+      // Force mediaRecorder to the state under test.
+      mockMediaRecorder.state = state;
       mockMediaRecorder.stop = vi.fn(() => {
         throw new Error('MediaRecorder.stop() failed');
       });
-      
-      // Try to stop recording - should not throw
+
       await audioHandler.stopRecordingFlow();
-      
-      // Should emit error event
-      expect(eventBusEmitSpy).toHaveBeenCalledWith(
-        APP_EVENTS.RECORDING_ERROR,
-        expect.objectContaining({ error: expect.any(String) })
-      );
-      
-      // Should still transition to stopping state
-      expect(audioHandler.stateMachine.getState()).toBe(RECORDING_STATES.STOPPING);
+
+      expectRecorderFailureRecovery();
     });
-    
+
   });
   
   describe('Audio Chunk Processing', () => {
@@ -440,40 +489,55 @@ describe('AudioHandler Integration', () => {
   });
   
   describe('Cleanup After Recording Errors', () => {
-    it('cleans up resources after MediaRecorder errors', async () => {
-      // Start recording
+    it('handles a registered fatal MediaRecorder error without processing a later stop event', async () => {
       await audioHandler.startRecordingFlow();
-      
+
       // Force mediaRecorder to active state
       mockMediaRecorder.state = 'recording';
-      
+
       // Trigger error event
       const error = new Error('MediaRecorder error');
-      mediaRecorderEventHandlers.error.forEach(handler => {
-        handler({ error });
+      expect(mediaRecorderEventHandlers.error).toHaveLength(1);
+      await mediaRecorderEventHandlers.error[0]({ error });
+      await Promise.all(mediaRecorderEventHandlers.stop.map(handler => handler()));
+
+      expect(mockApiClient.transcribe).not.toHaveBeenCalled();
+      expectRecorderFailureRecovery();
+    });
+
+    it('recovers to ERROR when a fatal MediaRecorder error arrives while cancelling', async () => {
+      await audioHandler.startRecordingFlow();
+      mockMediaRecorder.state = 'recording';
+
+      await audioHandler.cancelRecording();
+      expect(audioHandler.stateMachine.getState()).toBe(RECORDING_STATES.CANCELLING);
+      expect(mediaRecorderEventHandlers.error).toHaveLength(1);
+
+      await mediaRecorderEventHandlers.error[0]({
+        error: new Error('MediaRecorder error while cancelling')
       });
-      
-      // Wait for async operations
-      await new Promise(resolve => setTimeout(resolve, 10));
-      
-      // Stopping should still work after error
-      await audioHandler.stopRecordingFlow();
-      
-      // Trigger stop event
-      mediaRecorderEventHandlers.stop.forEach(handler => {
-        handler();
+      await Promise.all(mediaRecorderEventHandlers.stop.map(handler => handler()));
+
+      expect(mockApiClient.transcribe).not.toHaveBeenCalled();
+      expectRecorderFailureRecovery();
+    });
+
+    it('recovers to ERROR when a fatal MediaRecorder error arrives during discard confirmation', async () => {
+      await audioHandler.startRecordingFlow();
+      mockMediaRecorder.state = 'recording';
+      audioHandler.currentTimerDisplay = '00:10';
+
+      await audioHandler.requestDiscard();
+      expect(audioHandler.stateMachine.getState()).toBe(RECORDING_STATES.CONFIRMING_DISCARD);
+      expect(mediaRecorderEventHandlers.error).toHaveLength(1);
+
+      await mediaRecorderEventHandlers.error[0]({
+        error: new Error('MediaRecorder error during discard confirmation')
       });
-      
-      // Wait for async operations
-      await new Promise(resolve => setTimeout(resolve, 10));
-      
-      // Should have cleaned up resources
-      expect(audioHandler.audioChunks).toHaveLength(0);
-      expect(audioHandler.timerInterval).toBeNull();
-      expect(audioHandler.mediaRecorder).toBeNull();
-      
-      // Should be back in idle state
-      expect(audioHandler.stateMachine.getState()).toBe(RECORDING_STATES.IDLE);
+      await Promise.all(mediaRecorderEventHandlers.stop.map(handler => handler()));
+
+      expect(mockApiClient.transcribe).not.toHaveBeenCalled();
+      expectRecorderFailureRecovery();
     });
     
     it('cleans up resources after API errors', async () => {


### PR DESCRIPTION
## Summary

- make MediaRecorder lifecycle startup and failure recovery atomic
- clean up tracks, timers, visualization, and recorder sessions after constructor, start, stop, and runtime failures
- prevent stale stop events from triggering duplicate transcription
- add regression coverage for recording, paused, cancelling, and discard-confirmation failure paths
- record Plan 021 as implemented and independently approved

## Validation

- 356 Vitest tests passed
- coverage thresholds passed (93.42% statements, 87.88% branches)
- Playwright Chromium smoke passed
- lint, dependency checks, production dependency checks, and size budget passed
