### PR TITLE
fix: keep unsaved model selection draft-only

### DIFF
--- a/js/settings.js
+++ b/js/settings.js
@@ -183,10 +183,6 @@ export class Settings {
                 const settingsLogger = logger.child('Settings');
                 settingsLogger.info('Settings modal model changed to:', newModel, '(form only, not saved)');
                 
-                // Sync main interface selector to show current form selection
-                if (this.modelSelect) {
-                    this.modelSelect.value = newModel;
-                }
                 this.updateSettingsVisibility();
                 
                 // Do NOT emit any events until settings are saved
@@ -666,6 +662,8 @@ export class Settings {
         if (this.recordingEnvironmentSelect) {
             localStorage.setItem(STORAGE_KEYS.RECORDING_ENVIRONMENT, this.recordingEnvironmentSelect.value);
         }
+
+        this.modelSelect.value = currentModel;
 
         this.closeSettingsModal();
 

--- a/plans/README.md
+++ b/plans/README.md
@@ -47,7 +47,7 @@ and update your row when done.
 | 019 | Make adapter metadata authoritative for credential storage | P2 | M | — | DONE (implemented as `8db9d8d`, independently approved, and merged in PR #89 as `7930363`) |
 | 020 | Make transcript autosave observable and navigation-safe | P1 | S/M | — | DONE (implemented as `0e9a092`, independently approved, and merged via PR #91 as `a01298a`, 2026-07-13) |
 | 021 | Recover atomically from MediaRecorder lifecycle failures | P1 | M | — | DONE (implemented as `b490280`, independently approved, and merged via PR #93 as `339c561`, 2026-07-13) |
-| 022 | Keep unsaved settings-model changes draft-only | P1 | S | — | TODO |
+| 022 | Keep unsaved settings-model changes draft-only | P1 | S | — | DONE (implemented and independently approved as `6a3ff25` on `fix/022-settings-model-draft`; awaiting operator merge) |
 | 023 | Preserve the browser-selected recording container | P2 | M | 021 | TODO |
 | 024 | Enforce model-specific audio upload limits before network submission | P2 | M | 021 + 023 | TODO |
 | 025 | Make the settings modal keyboard and focus correct | P2 | M | 022 | TODO |

--- a/tests/settings-persistence.vitest.js
+++ b/tests/settings-persistence.vitest.js
@@ -245,6 +245,55 @@ describe('Settings Persistence & Save Workflow', () => {
             expect(eventBusEmitSpy).toHaveBeenCalledWith(APP_EVENTS.UI_SETTINGS_OPENED);
         });
 
+        test('should discard an unsaved model draft when closed with the close button', () => {
+            const modalModelSelect = settings.settingsModelSelect;
+            const modalChangeListener = modalModelSelect.addEventListener.mock.calls
+                .find(([eventName]) => eventName === 'change')[1];
+            const closeButtonListener = settings.closeModalButton.addEventListener.mock.calls
+                .find(([eventName]) => eventName === 'click')[1];
+
+            settings.modelSelect.value = MODEL_TYPES.WHISPER;
+            settings.openSettingsModal();
+            modalModelSelect.value = MODEL_TYPES.MAI_TRANSCRIBE_1_5;
+            modalChangeListener({ target: modalModelSelect });
+            closeButtonListener();
+
+            expect(settings.modelSelect.value).toBe(MODEL_TYPES.WHISPER);
+            expect(settings.getModelConfig().model).toBe(MODEL_TYPES.WHISPER);
+        });
+
+        test('should discard an unsaved model draft when closed with the backdrop', () => {
+            const modalModelSelect = settings.settingsModelSelect;
+            const modalChangeListener = modalModelSelect.addEventListener.mock.calls
+                .find(([eventName]) => eventName === 'change')[1];
+            const backdropListener = settings.settingsModal.addEventListener.mock.calls
+                .find(([eventName]) => eventName === 'click')[1];
+
+            settings.modelSelect.value = MODEL_TYPES.WHISPER;
+            settings.openSettingsModal();
+            modalModelSelect.value = MODEL_TYPES.MAI_TRANSCRIBE_1_5;
+            modalChangeListener({ target: modalModelSelect });
+            backdropListener({ target: settings.settingsModal });
+
+            expect(settings.modelSelect.value).toBe(MODEL_TYPES.WHISPER);
+            expect(settings.getModelConfig().model).toBe(MODEL_TYPES.WHISPER);
+        });
+
+        test('should restore the active model as the draft when reopened', () => {
+            const modalModelSelect = settings.settingsModelSelect;
+            const modalChangeListener = modalModelSelect.addEventListener.mock.calls
+                .find(([eventName]) => eventName === 'change')[1];
+
+            settings.modelSelect.value = MODEL_TYPES.WHISPER;
+            settings.openSettingsModal();
+            modalModelSelect.value = MODEL_TYPES.MAI_TRANSCRIBE_1_5;
+            modalChangeListener({ target: modalModelSelect });
+            settings.closeSettingsModal();
+            settings.openSettingsModal();
+
+            expect(modalModelSelect.value).toBe(MODEL_TYPES.WHISPER);
+        });
+
         test('should close the settings modal and emit event', () => {
             settings.closeSettingsModal();
 
@@ -453,6 +502,37 @@ describe('Settings Persistence & Save Workflow', () => {
                 })
             );
         });
+
+        test('should commit a valid modal model draft to active and persisted state exactly once', () => {
+            const maiApiKey = 'speech-resource-key-for-mai-15';
+            const maiApiUri = 'https://mai-transcribe.cognitiveservices.azure.com/speechtotext/transcriptions:transcribe?api-version=2025-10-15';
+            const modalModelSelect = settings.settingsModelSelect;
+            const modalChangeListener = modalModelSelect.addEventListener.mock.calls
+                .find(([eventName]) => eventName === 'change')[1];
+
+            settings.modelSelect.value = MODEL_TYPES.WHISPER;
+            settings.openSettingsModal();
+            modalModelSelect.value = MODEL_TYPES.MAI_TRANSCRIBE_1_5;
+            modalChangeListener({ target: modalModelSelect });
+            document.getElementById(ID.MAI_TRANSCRIBE_URI).value = maiApiUri;
+            document.getElementById(ID.MAI_TRANSCRIBE_KEY).value = maiApiKey;
+            localStorageMock.setItem.mockClear();
+            const observedModels = [];
+            const unsubscribe = eventBus.on(APP_EVENTS.SETTINGS_MODEL_CHANGED, () => {
+                observedModels.push(settings.getCurrentModel());
+            });
+
+            settings.saveSettings();
+
+            unsubscribe();
+
+            expect(settings.getCurrentModel()).toBe(MODEL_TYPES.MAI_TRANSCRIBE_1_5);
+            expect(settings.getModelConfig().model).toBe(MODEL_TYPES.MAI_TRANSCRIBE_1_5);
+            expect(observedModels).toEqual([MODEL_TYPES.MAI_TRANSCRIBE_1_5]);
+            expect(localStorageMock.setItem.mock.calls.filter(
+                ([key]) => key === STORAGE_KEYS.MODEL
+            )).toEqual([[STORAGE_KEYS.MODEL, MODEL_TYPES.MAI_TRANSCRIBE_1_5]]);
+        });
     });
 
     // ─── Save with Invalid Configuration (from settings-save-modal) ──────────
@@ -485,6 +565,28 @@ describe('Settings Persistence & Save Workflow', () => {
             expect(eventBusEmitSpy).not.toHaveBeenCalledWith(
                 APP_EVENTS.SETTINGS_LOADED,
                 expect.anything()
+            );
+        });
+
+        test('should keep the active model unchanged when saving an invalid modal draft', () => {
+            const modalModelSelect = settings.settingsModelSelect;
+            const modalChangeListener = modalModelSelect.addEventListener.mock.calls
+                .find(([eventName]) => eventName === 'change')[1];
+
+            settings.modelSelect.value = MODEL_TYPES.WHISPER;
+            settings.openSettingsModal();
+            modalModelSelect.value = MODEL_TYPES.MAI_TRANSCRIBE_1_5;
+            modalChangeListener({ target: modalModelSelect });
+            document.getElementById(ID.SETTINGS_MODAL).style.display = 'block';
+
+            settings.saveSettings();
+
+            expect(document.getElementById(ID.SETTINGS_MODAL).style.display).toBe('block');
+            expect(settings.getCurrentModel()).toBe(MODEL_TYPES.WHISPER);
+            expect(settings.getModelConfig().model).toBe(MODEL_TYPES.WHISPER);
+            expect(localStorageMock.setItem).not.toHaveBeenCalledWith(
+                STORAGE_KEYS.MODEL,
+                MODEL_TYPES.MAI_TRANSCRIBE_1_5
             );
         });
 


### PR DESCRIPTION
## Summary

- keep settings-modal model changes isolated as a draft until validation succeeds
- commit the selected model to the active session before save events are emitted
- cover close-button, backdrop, reopen, invalid-save, and valid-save behavior
- record Plan 022 as implemented and independently approved

## Validation

- 77 focused settings tests passed
- 361 full Vitest tests passed
- Playwright Chromium smoke passed
- coverage, lint, dependency checks, and size budget passed
