### PR TITLE
fix: preserve recorded audio container metadata

### DIFF
--- a/js/audio-handler.js
+++ b/js/audio-handler.js
@@ -291,9 +291,11 @@ export class AudioHandler {
 
         if (this.stateMachine.getState() !== RECORDING_STATES.STOPPING) return;
 
+        const recorderMimeType = session.recorder?.mimeType;
+
         // Transition to processing
         await this.stateMachine.transitionTo(RECORDING_STATES.PROCESSING);
-        await this.processAndSendAudio(session.stream);
+        await this.processAndSendAudio(session.stream, recorderMimeType);
 
         // Cleanup after audio has been processed so chunks remain intact
         this.cleanup();
@@ -506,10 +508,14 @@ export class AudioHandler {
      * @async
      * @method processAndSendAudio
      * @param {MediaStream} stream - The original audio media stream
+     * @param {string} recorderMimeType - MIME type selected by MediaRecorder
      * @returns {Promise<void>} Resolves when transcription is complete or error emitted
      */
-    async processAndSendAudio(stream) {
-        const audioBlob = new Blob(this.audioChunks, { type: 'audio/webm' });
+    async processAndSendAudio(stream, recorderMimeType = '') {
+        const chunkWithMimeType = this.audioChunks.find(chunk => chunk?.type);
+        const audioBlob = new Blob(this.audioChunks, {
+            type: recorderMimeType || chunkWithMimeType?.type || 'audio/webm'
+        });
         this.pendingRetryBlob = audioBlob;
 
         const result = await this.sendToAzureAPI(audioBlob);

--- a/js/constants.js
+++ b/js/constants.js
@@ -227,6 +227,50 @@ export const DEFAULT_LANGUAGE  = 'en';
 export const DEFAULT_FILENAME      = 'recording.webm';
 export const DEFAULT_WAV_FILENAME  = 'recording.wav';
 
+const WHISPER_FILENAMES_BY_MIME_TYPE = Object.freeze({
+  'audio/webm': DEFAULT_FILENAME,
+  'audio/mp3': 'recording.mp3',
+  'audio/mpeg': 'recording.mpeg',
+  'audio/mpga': 'recording.mpga',
+  'audio/mp4': 'recording.mp4',
+  'audio/m4a': 'recording.m4a',
+  'audio/x-m4a': 'recording.m4a',
+  'audio/wav': DEFAULT_WAV_FILENAME,
+  'audio/wave': DEFAULT_WAV_FILENAME,
+  'audio/x-wav': DEFAULT_WAV_FILENAME
+});
+
+/**
+ * Returns an Azure Whisper-compatible filename for an audio MIME type.
+ * MIME parameters are ignored for extension selection so the Blob preserves
+ * the exact container metadata selected by the browser.
+ * Empty types retain the WebM fallback used when capture metadata is absent.
+ *
+ * @param {string} mimeType - The audio Blob MIME type
+ * @returns {string} ASCII upload filename with a matching container extension
+ * @throws {Error} When the MIME type is unsupported by Azure Whisper
+ */
+export function getWhisperFilename(mimeType) {
+  const normalizedMimeType = typeof mimeType === 'string'
+    ? mimeType.split(';', 1)[0].trim().toLowerCase()
+    : '';
+
+  if (!normalizedMimeType) {
+    return DEFAULT_FILENAME;
+  }
+
+  const filename = WHISPER_FILENAMES_BY_MIME_TYPE[normalizedMimeType];
+
+  if (!filename) {
+    throw new Error(
+      `Unsupported audio MIME type for Whisper upload: ${mimeType || '(empty)'}. `
+      + 'Supported types: MP3, MP4, MPEG, MPGA, M4A, WAV, and WebM.'
+    );
+  }
+
+  return filename;
+}
+
 /**
  * Subtle visual divider inserted between appended transcript segments so
  * multi-take recordings stay legible and easy to trim.

--- a/js/model-adapters/whisper-translate.js
+++ b/js/model-adapters/whisper-translate.js
@@ -2,7 +2,7 @@
  * @fileoverview Model adapter for Azure Whisper translation requests.
  */
 
-import { API_PARAMS, DEFAULT_FILENAME, MESSAGES, MODEL_TYPES, STORAGE_KEYS } from '../constants.js';
+import { API_PARAMS, getWhisperFilename, MESSAGES, MODEL_TYPES, STORAGE_KEYS } from '../constants.js';
 import { parseWhisperResponse } from './response-parsers.js';
 
 export const whisperTranslateModelAdapter = {
@@ -13,8 +13,9 @@ export const whisperTranslateModelAdapter = {
         uri: STORAGE_KEYS.WHISPER_URI
     },
     async buildRequest(audioBlob, config) {
+        const filename = getWhisperFilename(audioBlob.type);
         const formData = new FormData();
-        formData.append(API_PARAMS.FILE, audioBlob, DEFAULT_FILENAME);
+        formData.append(API_PARAMS.FILE, audioBlob, filename);
 
         return {
             headers: { [API_PARAMS.API_KEY_HEADER]: config.apiKey },

--- a/js/model-adapters/whisper.js
+++ b/js/model-adapters/whisper.js
@@ -2,7 +2,7 @@
  * @fileoverview Model adapter for Azure Whisper transcription requests.
  */
 
-import { API_PARAMS, DEFAULT_FILENAME, DEFAULT_LANGUAGE, MESSAGES, MODEL_TYPES, STORAGE_KEYS } from '../constants.js';
+import { API_PARAMS, DEFAULT_LANGUAGE, getWhisperFilename, MESSAGES, MODEL_TYPES, STORAGE_KEYS } from '../constants.js';
 import { parseWhisperResponse } from './response-parsers.js';
 
 export const whisperModelAdapter = {
@@ -13,8 +13,9 @@ export const whisperModelAdapter = {
         uri: STORAGE_KEYS.WHISPER_URI
     },
     async buildRequest(audioBlob, config) {
+        const filename = getWhisperFilename(audioBlob.type);
         const formData = new FormData();
-        formData.append(API_PARAMS.FILE, audioBlob, DEFAULT_FILENAME);
+        formData.append(API_PARAMS.FILE, audioBlob, filename);
         formData.append(API_PARAMS.LANGUAGE, DEFAULT_LANGUAGE);
 
         return {

--- a/plans/023-preserve-recorded-audio-container.md
+++ b/plans/023-preserve-recorded-audio-container.md
@@ -3,7 +3,7 @@
 > **Executor instructions**: Follow this plan exactly, run every gate, and stop
 > on any STOP condition. Update only the plan status row in the index.
 >
-> **Drift check (run first)**: `git diff --stat 559124e..HEAD -- js/audio-handler.js js/constants.js js/model-adapters/whisper.js js/model-adapters/whisper-translate.js tests/audio-handler-integration.vitest.js tests/model-adapters.vitest.js`
+> **Drift check (run first)**: `git diff --stat 5430373..HEAD -- js/audio-handler.js js/constants.js js/model-adapters/whisper.js js/model-adapters/whisper-translate.js tests/audio-handler-integration.vitest.js tests/model-adapters.vitest.js`
 
 ## Status
 
@@ -12,7 +12,7 @@
 - **Risk**: MED
 - **Depends on**: Plan 021
 - **Category**: bug
-- **Planned at**: commit `559124e`, 2026-07-12
+- **Planned at**: refreshed at commit `5430373`, 2026-07-13 (after Plans 021–022)
 
 ## Why this matters
 
@@ -25,9 +25,9 @@ and MAI's deliberate WAV conversion.
 
 ## Current state
 
-- `js/audio-handler.js:182` constructs `new MediaRecorder(stream)` without
+- `js/audio-handler.js:205` constructs `new MediaRecorder(stream)` without
   forcing a type; the browser selects one.
-- `processAndSendAudio()` at `:373` uses
+- `processAndSendAudio()` at `:511-512` uses
   `new Blob(this.audioChunks, { type: 'audio/webm' })` unconditionally.
 - `DEFAULT_FILENAME = 'recording.webm'` at `js/constants.js:227` is used by both
   Whisper adapters.

--- a/plans/README.md
+++ b/plans/README.md
@@ -48,7 +48,7 @@ and update your row when done.
 | 020 | Make transcript autosave observable and navigation-safe | P1 | S/M | — | DONE (implemented as `0e9a092`, independently approved, and merged via PR #91 as `a01298a`, 2026-07-13) |
 | 021 | Recover atomically from MediaRecorder lifecycle failures | P1 | M | — | DONE (implemented as `b490280`, independently approved, and merged via PR #93 as `339c561`, 2026-07-13) |
 | 022 | Keep unsaved settings-model changes draft-only | P1 | S | — | DONE (implemented as `6a3ff25`, independently approved, and merged via PR #94 as `69e11a8`, 2026-07-13) |
-| 023 | Preserve the browser-selected recording container | P2 | M | 021 | TODO |
+| 023 | Preserve the browser-selected recording container | P2 | M | 021 | DONE (implemented and independently approved as `b2fb90b` on `fix/023-recording-container-metadata`; awaiting operator merge) |
 | 024 | Enforce model-specific audio upload limits before network submission | P2 | M | 021 + 023 | TODO |
 | 025 | Make the settings modal keyboard and focus correct | P2 | M | 022 | TODO |
 | 026 | Subscribe to microphone permission changes exactly once | P2 | S | 021 | TODO |

--- a/tests/audio-handler-integration.vitest.js
+++ b/tests/audio-handler-integration.vitest.js
@@ -42,10 +42,10 @@ document.body.innerHTML = `
 `;
 
 // Create mock audio chunks for testing
-const createAudioChunk = (size = 1024) => {
+const createAudioChunk = (size = 1024, type = 'audio/webm') => {
   return {
     size,
-    type: 'audio/webm',
+    type,
     arrayBuffer: vi.fn(() => Promise.resolve(new ArrayBuffer(size)))
   };
 };
@@ -90,6 +90,7 @@ describe('AudioHandler Integration', () => {
       resume: vi.fn(),
       requestData: vi.fn(),
       state: 'inactive',
+      mimeType: 'audio/webm',
       addEventListener: vi.fn((event, handler) => {
         mediaRecorderEventHandlers[event].push(handler);
       }),
@@ -301,6 +302,60 @@ describe('AudioHandler Integration', () => {
       
       // Should clear chunks after processing
       expect(audioHandler.audioChunks).toHaveLength(0);
+    });
+
+    it('preserves an MP4 container selected by MediaRecorder', async () => {
+      mockMediaRecorder.mimeType = 'audio/mp4';
+
+      await audioHandler.startRecordingFlow();
+      mockMediaRecorder.state = 'recording';
+      mediaRecorderEventHandlers.dataavailable.forEach(handler => {
+        handler({ data: createAudioChunk(1024, 'audio/mp4') });
+      });
+
+      await audioHandler.stopRecordingFlow();
+      await Promise.all(mediaRecorderEventHandlers.stop.map(handler => handler()));
+
+      expect(mockApiClient.transcribe).toHaveBeenCalledWith(
+        expect.objectContaining({ type: 'audio/mp4' }),
+        expect.any(Function)
+      );
+    });
+
+    it('uses a chunk container when MediaRecorder does not expose one', async () => {
+      mockMediaRecorder.mimeType = '';
+
+      await audioHandler.startRecordingFlow();
+      mockMediaRecorder.state = 'recording';
+      mediaRecorderEventHandlers.dataavailable.forEach(handler => {
+        handler({ data: createAudioChunk(1024, 'audio/mp4') });
+      });
+
+      await audioHandler.stopRecordingFlow();
+      await Promise.all(mediaRecorderEventHandlers.stop.map(handler => handler()));
+
+      expect(mockApiClient.transcribe).toHaveBeenCalledWith(
+        expect.objectContaining({ type: 'audio/mp4' }),
+        expect.any(Function)
+      );
+    });
+
+    it('uses audio/webm as the safe fallback when recorder and chunks have no type', async () => {
+      mockMediaRecorder.mimeType = '';
+
+      await audioHandler.startRecordingFlow();
+      mockMediaRecorder.state = 'recording';
+      mediaRecorderEventHandlers.dataavailable.forEach(handler => {
+        handler({ data: createAudioChunk(1024, '') });
+      });
+
+      await audioHandler.stopRecordingFlow();
+      await Promise.all(mediaRecorderEventHandlers.stop.map(handler => handler()));
+
+      expect(mockApiClient.transcribe).toHaveBeenCalledWith(
+        expect.objectContaining({ type: 'audio/webm' }),
+        expect.any(Function)
+      );
     });
     
     it('handles empty audio chunks gracefully', async () => {

--- a/tests/model-adapters.vitest.js
+++ b/tests/model-adapters.vitest.js
@@ -129,7 +129,7 @@ describe('AzureAPIClient model adapter registry', () => {
     });
 
     it('looks up the active model and routes request-building and parsing through the adapter', async () => {
-        const audioBlob = new Blob(['audio']);
+        const audioBlob = new Blob(['audio'], { type: 'audio/webm' });
         const onProgress = vi.fn();
         const fakeAdapter = {
             id: 'fake-model',
@@ -182,7 +182,7 @@ describe('AzureAPIClient model adapter registry', () => {
         const settings = createSettings(MODEL_TYPES.WHISPER);
         const apiClient = new AzureAPIClient(settings);
         const onProgress = vi.fn();
-        const audioBlob = new Blob(['audio']);
+        const audioBlob = new Blob(['audio'], { type: 'audio/webm' });
         mockTextResponse(' Whisper text ');
 
         const result = await apiClient.transcribe(audioBlob, onProgress);
@@ -227,7 +227,7 @@ describe('AzureAPIClient model adapter registry', () => {
         const apiClient = new AzureAPIClient(settings);
         mockJsonResponse({ unexpected: 'format' });
 
-        await expect(apiClient.transcribe(new Blob(['audio']))).rejects.toThrow(MESSAGES.UNKNOWN_API_RESPONSE);
+        await expect(apiClient.transcribe(new Blob(['audio'], { type: 'audio/webm' }))).rejects.toThrow(MESSAGES.UNKNOWN_API_RESPONSE);
 
         expect(eventBusEmitSpy).toHaveBeenCalledWith(APP_EVENTS.API_REQUEST_ERROR, {
             error: MESSAGES.UNKNOWN_API_RESPONSE
@@ -238,7 +238,7 @@ describe('AzureAPIClient model adapter registry', () => {
         const settings = createSettings(MODEL_TYPES.WHISPER_TRANSLATE);
         const apiClient = new AzureAPIClient(settings);
         const onProgress = vi.fn();
-        const audioBlob = new Blob(['audio']);
+        const audioBlob = new Blob(['audio'], { type: 'audio/webm' });
         mockJsonResponse({ text: 'Translated text' });
 
         const result = await apiClient.transcribe(audioBlob, onProgress);
@@ -256,11 +256,77 @@ describe('AzureAPIClient model adapter registry', () => {
         expect(apiClient.parseResponse(' Translated plain text ')).toBe('Translated plain text');
     });
 
+    it.each([
+        [MODEL_TYPES.WHISPER, 'audio/mp4; codecs=mp4a.40.2', 'recording.mp4'],
+        [MODEL_TYPES.WHISPER_TRANSLATE, 'audio/mp4; codecs=mp4a.40.2', 'recording.mp4'],
+        [MODEL_TYPES.WHISPER, 'audio/x-m4a', 'recording.m4a'],
+        [MODEL_TYPES.WHISPER_TRANSLATE, 'audio/x-m4a', 'recording.m4a'],
+        [MODEL_TYPES.WHISPER, 'audio/wav', 'recording.wav'],
+        [MODEL_TYPES.WHISPER_TRANSLATE, 'audio/wav', 'recording.wav']
+    ])('uploads %s audio with a filename matching %s', async (model, mimeType, filename) => {
+        const settings = createSettings(model);
+        const apiClient = new AzureAPIClient(settings);
+        const audioBlob = new Blob(['audio'], { type: mimeType });
+
+        if (model === MODEL_TYPES.WHISPER) {
+            mockTextResponse('Whisper text');
+        } else {
+            mockJsonResponse({ text: 'Translated text' });
+        }
+
+        await apiClient.transcribe(audioBlob);
+
+        expect(getFormEntry(API_PARAMS.FILE)).toEqual({
+            key: API_PARAMS.FILE,
+            value: audioBlob,
+            filename
+        });
+        expect(getFormEntry(API_PARAMS.FILE).value.type).toBe(mimeType);
+    });
+
+    it.each([MODEL_TYPES.WHISPER, MODEL_TYPES.WHISPER_TRANSLATE])(
+        'uses the WebM fallback filename only when %s audio has no MIME type',
+        async (model) => {
+            const settings = createSettings(model);
+            const apiClient = new AzureAPIClient(settings);
+            const audioBlob = new Blob(['audio']);
+
+            if (model === MODEL_TYPES.WHISPER) {
+                mockTextResponse('Whisper text');
+            } else {
+                mockJsonResponse({ text: 'Translated text' });
+            }
+
+            await apiClient.transcribe(audioBlob);
+
+            expect(getFormEntry(API_PARAMS.FILE)).toEqual({
+                key: API_PARAMS.FILE,
+                value: audioBlob,
+                filename: DEFAULT_FILENAME
+            });
+        }
+    );
+
+    it.each([MODEL_TYPES.WHISPER, MODEL_TYPES.WHISPER_TRANSLATE])(
+        'rejects unsupported %s audio before fetch',
+        async (model) => {
+            const settings = createSettings(model);
+            const apiClient = new AzureAPIClient(settings);
+            const audioBlob = new Blob(['audio'], { type: 'audio/ogg' });
+
+            await expect(apiClient.transcribe(audioBlob)).rejects.toThrow(
+                'Unsupported audio MIME type for Whisper upload: audio/ogg.'
+            );
+
+            expect(globalThis.fetch).not.toHaveBeenCalled();
+        }
+    );
+
     it('keeps the existing MAI-Transcribe request and parsed text behavior', async () => {
         const settings = createSettings(MODEL_TYPES.MAI_TRANSCRIBE_1_5);
         const apiClient = new AzureAPIClient(settings);
         const onProgress = vi.fn();
-        const audioBlob = new Blob(['audio']);
+        const audioBlob = new Blob(['captured audio'], { type: 'audio/mp4' });
         mockJsonResponse({
             combinedPhrases: [
                 { text: 'First segment.' },
@@ -287,6 +353,7 @@ describe('AzureAPIClient model adapter registry', () => {
         });
         expect(getFormEntry(API_PARAMS.FILE)).toBeUndefined();
         expect(getFormEntry(API_PARAMS.LANGUAGE)).toBeUndefined();
+        expect(audioBlob.type).toBe('audio/mp4');
         expect(convertToWav).toHaveBeenCalledWith(audioBlob);
         expect(onProgress).toHaveBeenCalledWith(MESSAGES.CONVERTING_AUDIO);
         expect(onProgress).toHaveBeenCalledWith(MESSAGES.SENDING_TO_MAI_TRANSCRIBE);


### PR DESCRIPTION
## Summary

- preserve MediaRecorder-selected or chunk-provided container MIME metadata
- derive matching Whisper upload filenames while rejecting explicit unsupported containers before fetch
- keep empty metadata on the established WebM fallback and MAI uploads on WAV
- add capture and adapter regression matrices

## Validation

- 57 focused tests passed
- 374 full tests and coverage passed
- Playwright Chromium smoke passed
- lint, dependency checks, and size budget passed
