### PR TITLE
fix: enforce transcription upload limits

### DIFF
--- a/js/audio-handler.js
+++ b/js/audio-handler.js
@@ -2,7 +2,13 @@
  * @fileoverview Audio recording and playback management for speech transcription.
  */
 
-import { RECORDING_STATES, MESSAGES, TIMER_CONFIG, DISCARD_CONFIRM_MIN_MS } from './constants.js';
+import {
+    AUDIO_UPLOAD_LIMIT_ERROR_CODE,
+    RECORDING_STATES,
+    MESSAGES,
+    TIMER_CONFIG,
+    DISCARD_CONFIRM_MIN_MS
+} from './constants.js';
 import { PermissionManager } from './permission-manager.js';
 import { RecordingStateMachine } from './recording-state-machine.js';
 import { eventBus, APP_EVENTS } from './event-bus.js';
@@ -528,7 +534,7 @@ export class AudioHandler {
         } else {
             await this.stateMachine.transitionTo(RECORDING_STATES.ERROR, {
                 error: result.error,
-                canRetry: Boolean(this.pendingRetryBlob)
+                canRetry: result.code !== AUDIO_UPLOAD_LIMIT_ERROR_CODE && Boolean(this.pendingRetryBlob)
             });
         }
     }
@@ -554,7 +560,7 @@ export class AudioHandler {
 
         await this.stateMachine.transitionTo(RECORDING_STATES.ERROR, {
             error: result.error,
-            canRetry: Boolean(this.pendingRetryBlob)
+            canRetry: result.code !== AUDIO_UPLOAD_LIMIT_ERROR_CODE && Boolean(this.pendingRetryBlob)
         });
     }
     
@@ -595,7 +601,7 @@ export class AudioHandler {
                 ? `${rawMessage}. ${MESSAGES.CHECK_INTERNET_CONNECTION}`
                 : rawMessage;
             // handleErrorState emits UI_STATUS_UPDATE with prefix + retry hint
-            return { success: false, error: errorMessage };
+            return { success: false, error: errorMessage, code: error?.code };
         }
     }
     

--- a/js/constants.js
+++ b/js/constants.js
@@ -104,6 +104,18 @@ export const MODEL_TYPES = {
 };
 
 /**
+ * Maximum inline audio upload sizes enforced by the model endpoints.
+ *
+ * Azure OpenAI Whisper: https://learn.microsoft.com/azure/foundry/openai/whisper-quickstart
+ * Azure MAI-Transcribe: https://learn.microsoft.com/azure/ai-services/speech-service/mai-transcribe
+ */
+export const WHISPER_MAX_UPLOAD_BYTES = 25 * 1024 * 1024;
+export const MAI_TRANSCRIBE_MAX_UPLOAD_BYTES = (300 * 1024 * 1024) - 1;
+
+/** Stable input-validation code for model upload-size failures. */
+export const AUDIO_UPLOAD_LIMIT_ERROR_CODE = 'audio-upload-limit-exceeded';
+
+/**
  * The model selected out of the box when the user has no saved preference.
  * Single source of truth for the default — referenced by the Settings
  * empty-state fallbacks and the validate-and-reset migration. Change here to
@@ -347,6 +359,7 @@ export const MESSAGES = {
   SENDING_TO_WHISPER: 'Sending to Azure Whisper API...',
   CONVERTING_AUDIO: 'Converting audio format...',
   SENDING_TO_MAI_TRANSCRIBE: 'Sending to Azure MAI-Transcribe API...',
+  AUDIO_UPLOAD_LIMIT_EXCEEDED: '{model} accepts recordings {limit}. Make a shorter recording and try again.',
   UNKNOWN_API_RESPONSE: 'Unknown response format from API',
   
   // Transcription
@@ -377,6 +390,20 @@ export const MESSAGES = {
   RETRY_TRANSCRIPTION: 'Retry transcription',
   REQUEST_TIMED_OUT: 'The request timed out. Check your connection and try again.',
 };
+
+/**
+ * Formats the shared model upload-limit message with the selected model's
+ * human-readable limit.
+ *
+ * @param {string} model - Selected model label
+ * @param {string} limit - Human-readable maximum upload size
+ * @returns {string} User-facing input validation message
+ */
+export function formatAudioUploadLimitMessage(model, limit) {
+  return MESSAGES.AUDIO_UPLOAD_LIMIT_EXCEEDED
+    .replace('{model}', model)
+    .replace('{limit}', limit);
+}
 
 /**
  * Maximum time to wait for a single transcription request attempt before

--- a/js/model-adapters/mai-transcribe.js
+++ b/js/model-adapters/mai-transcribe.js
@@ -2,7 +2,16 @@
  * @fileoverview Model adapter for Azure MAI-Transcribe requests.
  */
 
-import { API_PARAMS, DEFAULT_WAV_FILENAME, MESSAGES, MODEL_TYPES, STORAGE_KEYS } from '../constants.js';
+import {
+    AUDIO_UPLOAD_LIMIT_ERROR_CODE,
+    API_PARAMS,
+    DEFAULT_WAV_FILENAME,
+    formatAudioUploadLimitMessage,
+    MAI_TRANSCRIBE_MAX_UPLOAD_BYTES,
+    MESSAGES,
+    MODEL_TYPES,
+    STORAGE_KEYS
+} from '../constants.js';
 import { convertToWav } from '../audio-converter.js';
 import { parseMaiTranscribeResponse } from './response-parsers.js';
 
@@ -19,8 +28,19 @@ function createMaiTranscribeModelAdapter(id, label, apiModel) {
                 onProgress(MESSAGES.CONVERTING_AUDIO);
             }
 
-            const formData = new FormData();
             const wavBlob = await convertToWav(audioBlob);
+
+            if (wavBlob.size > MAI_TRANSCRIBE_MAX_UPLOAD_BYTES) {
+                const error = new Error(formatAudioUploadLimitMessage(
+                    'Azure MAI-Transcribe 1.5',
+                    'under 300 MB'
+                ));
+                error.code = AUDIO_UPLOAD_LIMIT_ERROR_CODE;
+                error.retryable = false;
+                throw error;
+            }
+
+            const formData = new FormData();
             formData.append(API_PARAMS.MAI_AUDIO_FIELD, wavBlob, DEFAULT_WAV_FILENAME);
             formData.append(API_PARAMS.MAI_DEFINITION_FIELD, JSON.stringify({
                 enhancedMode: {

--- a/js/model-adapters/whisper-translate.js
+++ b/js/model-adapters/whisper-translate.js
@@ -2,7 +2,16 @@
  * @fileoverview Model adapter for Azure Whisper translation requests.
  */
 
-import { API_PARAMS, getWhisperFilename, MESSAGES, MODEL_TYPES, STORAGE_KEYS } from '../constants.js';
+import {
+    AUDIO_UPLOAD_LIMIT_ERROR_CODE,
+    API_PARAMS,
+    formatAudioUploadLimitMessage,
+    getWhisperFilename,
+    MESSAGES,
+    MODEL_TYPES,
+    STORAGE_KEYS,
+    WHISPER_MAX_UPLOAD_BYTES
+} from '../constants.js';
 import { parseWhisperResponse } from './response-parsers.js';
 
 export const whisperTranslateModelAdapter = {
@@ -13,6 +22,13 @@ export const whisperTranslateModelAdapter = {
         uri: STORAGE_KEYS.WHISPER_URI
     },
     async buildRequest(audioBlob, config) {
+        if (audioBlob.size > WHISPER_MAX_UPLOAD_BYTES) {
+            const error = new Error(formatAudioUploadLimitMessage('Azure Whisper Translate', 'up to 25 MB'));
+            error.code = AUDIO_UPLOAD_LIMIT_ERROR_CODE;
+            error.retryable = false;
+            throw error;
+        }
+
         const filename = getWhisperFilename(audioBlob.type);
         const formData = new FormData();
         formData.append(API_PARAMS.FILE, audioBlob, filename);

--- a/js/model-adapters/whisper.js
+++ b/js/model-adapters/whisper.js
@@ -2,7 +2,17 @@
  * @fileoverview Model adapter for Azure Whisper transcription requests.
  */
 
-import { API_PARAMS, DEFAULT_LANGUAGE, getWhisperFilename, MESSAGES, MODEL_TYPES, STORAGE_KEYS } from '../constants.js';
+import {
+    AUDIO_UPLOAD_LIMIT_ERROR_CODE,
+    API_PARAMS,
+    DEFAULT_LANGUAGE,
+    formatAudioUploadLimitMessage,
+    getWhisperFilename,
+    MESSAGES,
+    MODEL_TYPES,
+    STORAGE_KEYS,
+    WHISPER_MAX_UPLOAD_BYTES
+} from '../constants.js';
 import { parseWhisperResponse } from './response-parsers.js';
 
 export const whisperModelAdapter = {
@@ -13,6 +23,13 @@ export const whisperModelAdapter = {
         uri: STORAGE_KEYS.WHISPER_URI
     },
     async buildRequest(audioBlob, config) {
+        if (audioBlob.size > WHISPER_MAX_UPLOAD_BYTES) {
+            const error = new Error(formatAudioUploadLimitMessage('Azure Whisper', 'up to 25 MB'));
+            error.code = AUDIO_UPLOAD_LIMIT_ERROR_CODE;
+            error.retryable = false;
+            throw error;
+        }
+
         const filename = getWhisperFilename(audioBlob.type);
         const formData = new FormData();
         formData.append(API_PARAMS.FILE, audioBlob, filename);

--- a/plans/024-enforce-audio-upload-limits.md
+++ b/plans/024-enforce-audio-upload-limits.md
@@ -4,7 +4,7 @@
 > condition. This plan protects service contracts; do not invent a lower product
 > recording-duration cap.
 >
-> **Drift check (run first)**: `git diff --stat 559124e..HEAD -- js/audio-handler.js js/constants.js js/model-adapters/whisper.js js/model-adapters/whisper-translate.js js/model-adapters/mai-transcribe.js tests/audio-handler-integration.vitest.js tests/model-adapters.vitest.js`
+> **Drift check (run first)**: `git diff --stat 2be9ecb..HEAD -- js/audio-handler.js js/constants.js js/model-adapters/whisper.js js/model-adapters/whisper-translate.js js/model-adapters/mai-transcribe.js tests/audio-handler-integration.vitest.js tests/model-adapters.vitest.js`
 
 ## Status
 
@@ -13,20 +13,22 @@
 - **Risk**: MED
 - **Depends on**: Plans 021 and 023
 - **Category**: perf
-- **Planned at**: commit `559124e`, 2026-07-12
+- **Planned at**: refreshed at commit `2be9ecb`, 2026-07-13 (after Plans 021 and 023)
 
 ## Why this matters
 
 Recording length and accumulated bytes are currently unbounded. Azure OpenAI
-Whisper rejects files over 25 MB; the MAI speech endpoint documents a 500 MB /
-five-hour input ceiling. Today an oversized recording consumes memory and
+Whisper rejects files over 25 MB; current model-specific MAI-Transcribe
+documentation requires files smaller than 300 MB (the generic LLM Speech API
+documents a broader 500 MB/five-hour ceiling). Apply the stricter model-specific
+limit. Today an oversized recording consumes memory and
 conversion time before receiving a predictable service error, and the same blob
 can be offered for futile retry. Encode limits in the adapters and reject before
 fetch, while leaving any stricter UX duration policy to a later product decision.
 
 ## Current state
 
-- `js/audio-handler.js:187-188` appends every `dataavailable` blob indefinitely.
+- `js/audio-handler.js:209-211` appends every `dataavailable` blob indefinitely.
 - `processAndSendAudio()` creates one complete Blob without a size check.
 - Whisper adapters append captured audio directly. MAI converts to WAV first,
   so its relevant upload size is the resulting `wavBlob.size`.
@@ -64,7 +66,9 @@ new Playwright tests.
 
 ### Step 1: Pin the limits and error contract
 
-Add named byte constants with source comments for Whisper 25 MB and MAI 500 MB.
+Add named byte constants with source comments for Whisper 25 MB and MAI's
+strictly-less-than-300-MB model limit. Represent the MAI maximum accepted byte
+count precisely so the boundary test can accept the maximum and reject +1.
 Add one shared user-facing message that names the selected model's maximum in
 human-readable units and recommends making a shorter recording. Tests must use
 small injected/overridden boundary values or Blob size stubs—never allocate
@@ -123,7 +127,8 @@ Run every command above, `git diff --check`, and `git diff --name-only`.
 
 ## STOP conditions
 
-- Current official service documentation no longer supports the stated limits.
+- Current official service documentation no longer supports the refreshed 25 MB
+  Whisper or under-300-MB MAI limits.
 - Enforcing MAI's limit requires materializing an extra full-size WAV copy.
 - Correct behavior requires automatic stopping at a product-selected duration.
 - Two in-scope attempts fail a required gate.

--- a/plans/README.md
+++ b/plans/README.md
@@ -49,7 +49,7 @@ and update your row when done.
 | 021 | Recover atomically from MediaRecorder lifecycle failures | P1 | M | — | DONE (implemented as `b490280`, independently approved, and merged via PR #93 as `339c561`, 2026-07-13) |
 | 022 | Keep unsaved settings-model changes draft-only | P1 | S | — | DONE (implemented as `6a3ff25`, independently approved, and merged via PR #94 as `69e11a8`, 2026-07-13) |
 | 023 | Preserve the browser-selected recording container | P2 | M | 021 | DONE (implemented as `b2fb90b`, independently approved, and merged via PR #95 as `63a2c8b`, 2026-07-13) |
-| 024 | Enforce model-specific audio upload limits before network submission | P2 | M | 021 + 023 | TODO |
+| 024 | Enforce model-specific audio upload limits before network submission | P2 | M | 021 + 023 | DONE (implemented and independently approved as `daabc17` on `fix/024-audio-upload-limits`; awaiting operator merge) |
 | 025 | Make the settings modal keyboard and focus correct | P2 | M | 022 | TODO |
 | 026 | Subscribe to microphone permission changes exactly once | P2 | S | 021 | TODO |
 | 027 | Normalize API lifecycle events and opt in to event history | P2 | S/M | 021 | TODO |

--- a/tests/audio-handler-integration.vitest.js
+++ b/tests/audio-handler-integration.vitest.js
@@ -51,11 +51,11 @@ const createAudioChunk = (size = 1024, type = 'audio/webm') => {
 };
 
 // Import modules before tests
-let AudioHandler, eventBus, APP_EVENTS, RECORDING_STATES;
+let AudioHandler, eventBus, APP_EVENTS, AUDIO_UPLOAD_LIMIT_ERROR_CODE, RECORDING_STATES;
 
 beforeAll(async () => {
   ({ eventBus, APP_EVENTS } = await import('../js/event-bus.js'));
-  ({ RECORDING_STATES } = await import('../js/constants.js'));
+  ({ AUDIO_UPLOAD_LIMIT_ERROR_CODE, RECORDING_STATES } = await import('../js/constants.js'));
   ({ AudioHandler } = await import('../js/audio-handler.js'));
 });
 
@@ -388,6 +388,36 @@ describe('AudioHandler Integration', () => {
   });
 
   describe('Transcription retry', () => {
+    it('carries an upload-limit error code through sendToAzureAPI', async () => {
+      const uploadLimitError = new Error('Azure Whisper accepts recordings up to 25 MB. Make a shorter recording and try again.');
+      uploadLimitError.code = AUDIO_UPLOAD_LIMIT_ERROR_CODE;
+      mockApiClient.transcribe.mockRejectedValueOnce(uploadLimitError);
+
+      await expect(audioHandler.sendToAzureAPI(new Blob(['audio'], { type: 'audio/webm' }))).resolves.toEqual({
+        success: false,
+        error: uploadLimitError.message,
+        code: AUDIO_UPLOAD_LIMIT_ERROR_CODE
+      });
+    });
+
+    it('retains an oversized blob for error handling without offering Retry', async () => {
+      const uploadLimitError = new Error('Azure Whisper accepts recordings up to 25 MB. Make a shorter recording and try again.');
+      uploadLimitError.code = AUDIO_UPLOAD_LIMIT_ERROR_CODE;
+      mockApiClient.transcribe.mockRejectedValueOnce(uploadLimitError);
+      audioHandler.audioChunks = [new Uint8Array([1, 2, 3])];
+
+      await audioHandler.processAndSendAudio(mockStream);
+
+      expect(audioHandler.pendingRetryBlob).toBeInstanceOf(Blob);
+      expect(eventBusEmitSpy).toHaveBeenCalledWith(
+        APP_EVENTS.RECORDING_STATE_CHANGED,
+        expect.objectContaining({
+          newState: RECORDING_STATES.ERROR,
+          canRetry: false
+        })
+      );
+    });
+
     it('preserves failed audio and retries the same blob', async () => {
       const trackStopSpy = vi.fn();
       const mockStream = {
@@ -407,6 +437,13 @@ describe('AudioHandler Integration', () => {
       expect(audioHandler.stateMachine.getState()).toBe(RECORDING_STATES.ERROR);
       expect(trackStopSpy).toHaveBeenCalled();
       expect(audioHandler.pendingRetryBlob).toBeInstanceOf(Blob);
+      expect(eventBusEmitSpy).toHaveBeenCalledWith(
+        APP_EVENTS.RECORDING_STATE_CHANGED,
+        expect.objectContaining({
+          newState: RECORDING_STATES.ERROR,
+          canRetry: true
+        })
+      );
       const failedAudioBlob = audioHandler.pendingRetryBlob;
 
       await audioHandler.retryPendingTranscription();

--- a/tests/model-adapters.vitest.js
+++ b/tests/model-adapters.vitest.js
@@ -4,13 +4,17 @@
 
 import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 import {
+    AUDIO_UPLOAD_LIMIT_ERROR_CODE,
     API_PARAMS,
     DEFAULT_FILENAME,
     DEFAULT_LANGUAGE,
     DEFAULT_WAV_FILENAME,
+    formatAudioUploadLimitMessage,
+    MAI_TRANSCRIBE_MAX_UPLOAD_BYTES,
     MESSAGES,
     MODEL_TYPES,
-    STORAGE_KEYS
+    STORAGE_KEYS,
+    WHISPER_MAX_UPLOAD_BYTES
 } from '../js/constants.js';
 import { convertToWav } from '../js/audio-converter.js';
 import { APP_EVENTS, eventBus } from '../js/event-bus.js';
@@ -85,6 +89,12 @@ function getFetchOptions() {
 
 function getFormEntry(key) {
     return getFetchOptions().body.appended.find(entry => entry.key === key);
+}
+
+function createBlobWithStubbedSize(size, type = 'audio/webm') {
+    const audioBlob = new Blob(['audio'], { type });
+    Object.defineProperty(audioBlob, 'size', { value: size });
+    return audioBlob;
 }
 
 let AzureAPIClient;
@@ -257,6 +267,45 @@ describe('AzureAPIClient model adapter registry', () => {
     });
 
     it.each([
+        [MODEL_TYPES.WHISPER, 'Azure Whisper'],
+        [MODEL_TYPES.WHISPER_TRANSLATE, 'Azure Whisper Translate']
+    ])('accepts %s audio below and at the 25 MB upload limit', async (model) => {
+        const settings = createSettings(model);
+        const apiClient = new AzureAPIClient(settings);
+
+        if (model === MODEL_TYPES.WHISPER) {
+            mockTextResponse('Whisper text');
+        } else {
+            mockJsonResponse({ text: 'Translated text' });
+        }
+
+        await apiClient.transcribe(createBlobWithStubbedSize(WHISPER_MAX_UPLOAD_BYTES - 1));
+        await apiClient.transcribe(createBlobWithStubbedSize(WHISPER_MAX_UPLOAD_BYTES));
+
+        expect(globalThis.fetch).toHaveBeenCalledTimes(2);
+        expect(globalThis.FormData).toHaveBeenCalledTimes(2);
+    });
+
+    it.each([
+        [MODEL_TYPES.WHISPER, 'Azure Whisper'],
+        [MODEL_TYPES.WHISPER_TRANSLATE, 'Azure Whisper Translate']
+    ])('rejects %s audio one byte above the 25 MB upload limit before request construction', async (model, label) => {
+        const settings = createSettings(model);
+        const apiClient = new AzureAPIClient(settings);
+
+        await expect(apiClient.transcribe(
+            createBlobWithStubbedSize(WHISPER_MAX_UPLOAD_BYTES + 1)
+        )).rejects.toMatchObject({
+            code: AUDIO_UPLOAD_LIMIT_ERROR_CODE,
+            retryable: false,
+            message: formatAudioUploadLimitMessage(label, 'up to 25 MB')
+        });
+
+        expect(globalThis.FormData).not.toHaveBeenCalled();
+        expect(globalThis.fetch).not.toHaveBeenCalled();
+    });
+
+    it.each([
         [MODEL_TYPES.WHISPER, 'audio/mp4; codecs=mp4a.40.2', 'recording.mp4'],
         [MODEL_TYPES.WHISPER_TRANSLATE, 'audio/mp4; codecs=mp4a.40.2', 'recording.mp4'],
         [MODEL_TYPES.WHISPER, 'audio/x-m4a', 'recording.m4a'],
@@ -361,6 +410,43 @@ describe('AzureAPIClient model adapter registry', () => {
             combinedPhrases: [{ text: 'Combined output.' }],
             text: 'Text field output.'
         })).toBe('Combined output.');
+    });
+
+    it('accepts MAI audio at the strict less-than-300-MB boundary after conversion', async () => {
+        const settings = createSettings(MODEL_TYPES.MAI_TRANSCRIBE_1_5);
+        const apiClient = new AzureAPIClient(settings);
+        const sourceBlob = createBlobWithStubbedSize(MAI_TRANSCRIBE_MAX_UPLOAD_BYTES + 1);
+        const wavBlob = createBlobWithStubbedSize(MAI_TRANSCRIBE_MAX_UPLOAD_BYTES, 'audio/wav');
+        convertToWav.mockResolvedValueOnce(wavBlob);
+        mockJsonResponse({ text: 'MAI transcription' });
+
+        await expect(apiClient.transcribe(sourceBlob)).resolves.toBe('MAI transcription');
+
+        expect(convertToWav).toHaveBeenCalledWith(sourceBlob);
+        expect(getFormEntry(API_PARAMS.MAI_AUDIO_FIELD)).toEqual({
+            key: API_PARAMS.MAI_AUDIO_FIELD,
+            value: wavBlob,
+            filename: DEFAULT_WAV_FILENAME
+        });
+        expect(globalThis.fetch).toHaveBeenCalledTimes(1);
+    });
+
+    it('rejects an oversized MAI WAV after conversion and before request construction', async () => {
+        const settings = createSettings(MODEL_TYPES.MAI_TRANSCRIBE_1_5);
+        const apiClient = new AzureAPIClient(settings);
+        const sourceBlob = createBlobWithStubbedSize(1);
+        const oversizedWavBlob = createBlobWithStubbedSize(MAI_TRANSCRIBE_MAX_UPLOAD_BYTES + 1, 'audio/wav');
+        convertToWav.mockResolvedValueOnce(oversizedWavBlob);
+
+        await expect(apiClient.transcribe(sourceBlob)).rejects.toMatchObject({
+            code: AUDIO_UPLOAD_LIMIT_ERROR_CODE,
+            retryable: false,
+            message: formatAudioUploadLimitMessage('Azure MAI-Transcribe 1.5', 'under 300 MB')
+        });
+
+        expect(convertToWav).toHaveBeenCalledWith(sourceBlob);
+        expect(globalThis.FormData).not.toHaveBeenCalled();
+        expect(globalThis.fetch).not.toHaveBeenCalled();
     });
 
 });


### PR DESCRIPTION
## Summary

- enforce current model-specific audio upload ceilings before network submission
- validate MAI on the converted WAV and Whisper/Translate on captured input
- classify oversize input as non-retryable while preserving network retry behavior
- refresh MAI contract from stale 500 MB to current under-300-MB guidance

## Validation

- 95 focused tests and 382 full tests passed
- coverage and Chromium smoke passed
- lint, dependency checks, and size budget passed
