### PR TITLE
Make settings modal keyboard and focus correct

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -1000,14 +1000,45 @@ header {
     position: fixed;
     z-index: 1000;
     inset: 0;
+    box-sizing: border-box;
+    width: 100vw;
+    max-width: none;
+    height: 100vh;
+    max-height: none;
+    margin: 0;
+    padding: 0;
+    border: 0;
+    background: transparent;
+    overflow-y: auto;
 }
 
-.modal-backdrop {
-    position: absolute;
-    inset: 0;
+.modal[open] {
+    display: block;
+}
+
+.modal.modal--fallback-open {
+    display: block;
+}
+
+.modal::backdrop {
     background: var(--modal-backdrop);
     backdrop-filter: blur(8px);
     -webkit-backdrop-filter: blur(8px);
+}
+
+.modal.modal--fallback-open::before {
+    content: '';
+    position: fixed;
+    z-index: 0;
+    inset: 0;
+    background: var(--modal-backdrop);
+    pointer-events: none;
+    backdrop-filter: blur(8px);
+    -webkit-backdrop-filter: blur(8px);
+}
+
+.modal.modal--fallback-open .modal-content {
+    z-index: 1;
 }
 
 .modal-content {

--- a/index.html
+++ b/index.html
@@ -232,8 +232,7 @@
     </dialog>
 
     <!-- Settings Modal -->
-    <div id="settings-modal" class="modal" role="dialog" aria-modal="true" aria-labelledby="modal-title">
-        <div class="modal-backdrop"></div>
+    <dialog id="settings-modal" class="modal" aria-labelledby="modal-title">
         <div class="modal-content">
             <div class="modal-header">
                 <h3 class="modal-title" id="modal-title">API Settings</h3>
@@ -278,7 +277,7 @@
 
             <button id="save-settings" class="save-button">Save Settings</button>
         </div>
-    </div>
+    </dialog>
 
     <script type="module" src="js/main.js"></script>
 </body>

--- a/js/settings.js
+++ b/js/settings.js
@@ -63,6 +63,11 @@ export class Settings {
         this.panelBackdrop = document.getElementById(ID.PANEL_BACKDROP);
         this.noiseToggle = document.getElementById(ID.NOISE_TOGGLE);
         this.inputDeviceSelect = document.getElementById(ID.INPUT_DEVICE);
+        this._settingsModalInvoker = null;
+        this._settingsModalIsOpen = false;
+        this._settingsModalUsesNativeDialog = false;
+        this._fallbackModalAttributes = null;
+        this._fallbackBackgroundState = [];
 
         this.init();
     }
@@ -192,7 +197,7 @@ export class Settings {
         
         // Settings button listener (now inside the panel footer)
         this.settingsButton.addEventListener('click', () => {
-            this.openSettingsModal();
+            this.openSettingsModal(this.settingsButton);
         });
         
         // Close modal listeners
@@ -201,10 +206,35 @@ export class Settings {
         });
         
         this.settingsModal.addEventListener('click', (e) => {
-            if (e.target === this.settingsModal || e.target.classList.contains('modal-backdrop')) {
+            if (e.target === this.settingsModal || e.target?.classList?.contains('modal-backdrop')) {
                 this.closeSettingsModal();
             }
         });
+
+        // Native <dialog> dispatches 'cancel' for Escape. Prevent its automatic
+        // close so every exit takes the same draft-discard and focus-return path.
+        this.settingsModal.addEventListener('cancel', (event) => {
+            if (!this._settingsModalIsOpen) return;
+            event.preventDefault();
+            this.closeSettingsModal();
+        });
+
+        // Browsers without showModal() need their own Escape and Tab handling.
+        // Native dialogs retain browser-provided containment and never enter this path.
+        this._fallbackModalKeydownHandler = (event) => {
+            if (!this._settingsModalIsOpen || this._settingsModalUsesNativeDialog) return;
+
+            if (event.key === 'Escape') {
+                event.preventDefault?.();
+                event.stopImmediatePropagation?.();
+                this.closeSettingsModal();
+            } else if (event.key === 'Tab') {
+                this._containFallbackModalFocus(event);
+            }
+        };
+        if (document.addEventListener) {
+            document.addEventListener('keydown', this._fallbackModalKeydownHandler);
+        }
         
         // Save settings listener
         this.saveSettingsButton.addEventListener('click', () => {
@@ -312,6 +342,7 @@ export class Settings {
         // Escape key → close sidebar
         this._panelEscHandler = (e) => {
             if (e.key === 'Escape') {
+                if (this._settingsModalIsOpen) return;
                 if (this._isSidebarPinned()) {
                     this.unpinSidebar();
                 } else if (this.sidePanel?.classList.contains('hover-preview')) {
@@ -457,13 +488,31 @@ export class Settings {
      * Opens the settings modal, loads current settings into form, and emits open event.
      * 
      * @method openSettingsModal
+     * @param {HTMLElement|null} [invoker] Element that opened the modal, if known.
      * @fires APP_EVENTS.UI_SETTINGS_OPENED
      * @returns {void}
      */
-    openSettingsModal() {
+    openSettingsModal(invoker = null) {
+        this._settingsModalInvoker = this._getSettingsModalInvoker(invoker);
         this.loadSettingsToForm();
         this.updateSettingsVisibility();
-        this.settingsModal.style.display = 'block';
+
+        this._settingsModalUsesNativeDialog = false;
+        if (typeof this.settingsModal?.showModal === 'function') {
+            try {
+                if (!this.settingsModal.open) {
+                    this.settingsModal.showModal();
+                }
+                this._settingsModalUsesNativeDialog = true;
+            } catch {
+                this._activateFallbackModal();
+            }
+        } else {
+            this._activateFallbackModal();
+        }
+
+        this._settingsModalIsOpen = true;
+        this._focusSettingsModalEntry();
 
         eventBus.emit(APP_EVENTS.UI_SETTINGS_OPENED);
     }
@@ -476,9 +525,264 @@ export class Settings {
      * @returns {void}
      */
     closeSettingsModal() {
-        this.settingsModal.style.display = 'none';
+        this._discardSettingsDraft();
+
+        if (!this._settingsModalUsesNativeDialog) {
+            this._deactivateFallbackModal();
+        }
+
+        if (
+            this._settingsModalUsesNativeDialog &&
+            this.settingsModal?.open &&
+            typeof this.settingsModal.close === 'function'
+        ) {
+            try {
+                this.settingsModal.close();
+            } catch {
+                this.settingsModal.style.display = 'none';
+            }
+        } else if (this.settingsModal) {
+            this.settingsModal.style.display = 'none';
+        }
+
+        this._settingsModalIsOpen = false;
+        this._settingsModalUsesNativeDialog = false;
+        this._restoreSettingsModalFocus();
         
         eventBus.emit(APP_EVENTS.UI_SETTINGS_CLOSED);
+    }
+
+    /**
+     * Provides visual and accessibility modality when showModal() is absent
+     * or fails. This path deliberately remains separate from native dialogs.
+     *
+     * @private
+     * @returns {void}
+     */
+    _activateFallbackModal() {
+        if (!this.settingsModal) return;
+
+        this._fallbackModalAttributes = ['role', 'aria-modal', 'tabindex'].map((name) => ({
+            name,
+            value: this.settingsModal.getAttribute?.(name),
+            hadAttribute: this.settingsModal.hasAttribute?.(name) ?? false
+        }));
+        this.settingsModal.classList?.add('modal--fallback-open');
+        this.settingsModal.setAttribute?.('role', 'dialog');
+        this.settingsModal.setAttribute?.('aria-modal', 'true');
+        this.settingsModal.setAttribute?.('tabindex', '-1');
+        this.settingsModal.style.display = 'block';
+        this._setFallbackBackgroundInert();
+    }
+
+    /**
+     * Restores document and dialog state changed for the fallback modal.
+     *
+     * @private
+     * @returns {void}
+     */
+    _deactivateFallbackModal() {
+        if (this.settingsModal) {
+            this.settingsModal.classList?.remove('modal--fallback-open');
+            this._fallbackModalAttributes?.forEach(({ name, value, hadAttribute }) => {
+                if (hadAttribute) {
+                    this.settingsModal.setAttribute?.(name, value);
+                } else {
+                    this.settingsModal.removeAttribute?.(name);
+                }
+            });
+        }
+        this._fallbackModalAttributes = null;
+        this._restoreFallbackBackground();
+    }
+
+    /**
+     * Gets document siblings that should be inert while the fallback is open.
+     *
+     * @private
+     * @returns {HTMLElement[]} Background elements outside the settings modal.
+     */
+    _getFallbackBackgroundElements() {
+        const bodyChildren = document.body?.children ? Array.from(document.body.children) : [];
+        return bodyChildren.filter((element) => (
+            element !== this.settingsModal && element.tagName !== 'SCRIPT'
+        ));
+    }
+
+    /**
+     * Makes background content unavailable to assistive technology and input.
+     *
+     * @private
+     * @returns {void}
+     */
+    _setFallbackBackgroundInert() {
+        this._fallbackBackgroundState = this._getFallbackBackgroundElements().map((element) => ({
+            element,
+            inert: element.inert,
+            supportsInert: 'inert' in element,
+            ariaHidden: element.getAttribute?.('aria-hidden'),
+            hadAriaHidden: element.hasAttribute?.('aria-hidden') ?? false
+        }));
+
+        this._fallbackBackgroundState.forEach(({ element }) => {
+            element.inert = true;
+            element.setAttribute?.('aria-hidden', 'true');
+        });
+    }
+
+    /**
+     * Restores background input and accessibility state after fallback close.
+     *
+     * @private
+     * @returns {void}
+     */
+    _restoreFallbackBackground() {
+        this._fallbackBackgroundState.forEach(({
+            element, inert, supportsInert, ariaHidden, hadAriaHidden
+        }) => {
+            if (supportsInert) {
+                element.inert = inert;
+            } else {
+                delete element.inert;
+            }
+            if (hadAriaHidden) {
+                element.setAttribute?.('aria-hidden', ariaHidden);
+            } else {
+                element.removeAttribute?.('aria-hidden');
+            }
+        });
+        this._fallbackBackgroundState = [];
+    }
+
+    /**
+     * Keeps keyboard focus in the fallback dialog without duplicating native
+     * dialog behavior when showModal() is available.
+     *
+     * @private
+     * @param {KeyboardEvent} event Tab keydown event.
+     * @returns {void}
+     */
+    _containFallbackModalFocus(event) {
+        const focusable = this._getFallbackModalFocusableElements();
+        if (focusable.length === 0) {
+            event.preventDefault?.();
+            this.settingsModal?.focus?.();
+            return;
+        }
+
+        const first = focusable[0];
+        const last = focusable[focusable.length - 1];
+        const target = event.target || document.activeElement;
+        const isInsideModal = this.settingsModal?.contains
+            ? this.settingsModal.contains(target)
+            : focusable.includes(target);
+
+        if (event.shiftKey && (target === first || !isInsideModal)) {
+            event.preventDefault?.();
+            last.focus();
+        } else if (!event.shiftKey && (target === last || !isInsideModal)) {
+            event.preventDefault?.();
+            first.focus();
+        }
+    }
+
+    /**
+     * Collects visible, enabled controls that can receive fallback Tab focus.
+     *
+     * @private
+     * @returns {HTMLElement[]} Focusable modal controls in document order.
+     */
+    _getFallbackModalFocusableElements() {
+        if (!this.settingsModal?.querySelectorAll) return [];
+
+        const selector = [
+            'a[href]',
+            'button:not([disabled])',
+            'input:not([disabled]):not([type="hidden"])',
+            'select:not([disabled])',
+            'textarea:not([disabled])',
+            '[tabindex]:not([tabindex="-1"])'
+        ].join(',');
+        return Array.from(this.settingsModal.querySelectorAll(selector)).filter((element) => (
+            !element.hidden &&
+            element.getAttribute?.('aria-hidden') !== 'true' &&
+            (!('offsetParent' in element) || element.offsetParent !== null)
+        ));
+    }
+
+    /**
+     * Restores the modal selector to the active session model when the modal
+     * exits without leaving an unsaved model draft behind.
+     *
+     * @private
+     * @returns {void}
+     */
+    _discardSettingsDraft() {
+        if (this.settingsModelSelect) {
+            this.settingsModelSelect.value = this.getCurrentModel();
+        }
+        this.updateSettingsVisibility();
+    }
+
+    /**
+     * Returns a focusable modal invoker, excluding startup's unfocused body.
+     *
+     * @private
+     * @param {HTMLElement|null} invoker Explicit invoking element, if known.
+     * @returns {HTMLElement|null} Focusable element to restore on close.
+     */
+    _getSettingsModalInvoker(invoker) {
+        const candidate = invoker || document.activeElement;
+        if (
+            candidate &&
+            candidate !== document.body &&
+            candidate !== document.documentElement &&
+            candidate.isConnected !== false &&
+            typeof candidate.focus === 'function'
+        ) {
+            return candidate;
+        }
+        return null;
+    }
+
+    /**
+     * Focuses an invalid active credential field, or the model selector when
+     * the active configuration is already valid.
+     *
+     * @private
+     * @returns {void}
+     */
+    _focusSettingsModalEntry() {
+        const { apiKeyInput, uriInput } = this._getActiveInputs();
+        const firstError = this.getValidationErrors()[0];
+        const apiKeyErrors = [
+            MESSAGES.API_KEY_REQUIRED,
+            MESSAGES.INVALID_API_KEY_CHARACTERS,
+            'Invalid API key format'
+        ];
+        const focusTarget = firstError
+            ? (apiKeyErrors.includes(firstError) ? apiKeyInput : uriInput)
+            : this.settingsModelSelect;
+
+        if (focusTarget && typeof focusTarget.focus === 'function') {
+            focusTarget.focus();
+        }
+    }
+
+    /**
+     * Restores focus to the element that opened the dialog when it remains in
+     * the document. Startup openings have no meaningful invoker to restore.
+     *
+     * @private
+     * @returns {void}
+     */
+    _restoreSettingsModalFocus() {
+        const invoker = this._settingsModalInvoker;
+        this._settingsModalInvoker = null;
+
+        if (invoker && invoker.isConnected !== false && typeof invoker.focus === 'function') {
+            invoker.focus();
+        }
     }
 
     /**
@@ -779,6 +1083,10 @@ export class Settings {
         if (this._panelEscHandler && document.removeEventListener) {
             document.removeEventListener('keydown', this._panelEscHandler);
         }
+        if (this._fallbackModalKeydownHandler && document.removeEventListener) {
+            document.removeEventListener('keydown', this._fallbackModalKeydownHandler);
+        }
+        this._deactivateFallbackModal();
         if (this._offPermissionGranted) {
             this._offPermissionGranted();
             this._offPermissionGranted = null;

--- a/plans/025-make-settings-modal-accessible.md
+++ b/plans/025-make-settings-modal-accessible.md
@@ -3,7 +3,7 @@
 > **Executor instructions**: Follow the plan step by step, preserve Plan 022's
 > draft semantics, and stop on any STOP condition.
 >
-> **Drift check (run first)**: `git diff --stat 559124e..HEAD -- index.html css/styles.css js/settings.js tests/settings-persistence.vitest.js tests/settings-unit.vitest.js`
+> **Drift check (run first)**: `git diff --stat 90e467e..HEAD -- index.html css/styles.css js/settings.js tests/settings-persistence.vitest.js tests/settings-unit.vitest.js`
 
 ## Status
 
@@ -12,7 +12,7 @@
 - **Risk**: MED
 - **Depends on**: Plan 022
 - **Category**: bug
-- **Planned at**: commit `559124e`, 2026-07-12
+- **Planned at**: refreshed at commit `90e467e`, 2026-07-13 (after Plan 022)
 
 ## Why this matters
 
@@ -26,7 +26,7 @@ Use the repository's native discard dialog pattern and preserve a safe fallback.
 
 - `index.html:235-280` uses a `<div id="settings-modal" class="modal"
   role="dialog" aria-modal="true">` with a manual backdrop.
-- `js/settings.js:467-485` only writes `style.display` and emits open/close.
+- `js/settings.js:466-485` only writes `style.display` and emits open/close.
 - The document Escape listener at `settings.js:316-328` controls only the
   sidebar.
 - `index.html:225-232` and `js/ui.js:134-146,620-656` are the established native

--- a/plans/README.md
+++ b/plans/README.md
@@ -50,7 +50,7 @@ and update your row when done.
 | 022 | Keep unsaved settings-model changes draft-only | P1 | S | — | DONE (implemented as `6a3ff25`, independently approved, and merged via PR #94 as `69e11a8`, 2026-07-13) |
 | 023 | Preserve the browser-selected recording container | P2 | M | 021 | DONE (implemented as `b2fb90b`, independently approved, and merged via PR #95 as `63a2c8b`, 2026-07-13) |
 | 024 | Enforce model-specific audio upload limits before network submission | P2 | M | 021 + 023 | DONE (implemented as `daabc17`, independently approved, and merged via PR #96 as `54f4376`, 2026-07-13) |
-| 025 | Make the settings modal keyboard and focus correct | P2 | M | 022 | TODO |
+| 025 | Make the settings modal keyboard and focus correct | P2 | M | 022 | IN PROGRESS (implemented as `9d6d5a3`, independently approved; awaiting merge) |
 | 026 | Subscribe to microphone permission changes exactly once | P2 | S | 021 | TODO |
 | 027 | Normalize API lifecycle events and opt in to event history | P2 | S/M | 021 | TODO |
 | 028 | Provide one supported local-development command and runtime baseline | P2 | S/M | — | TODO |

--- a/tests/settings-persistence.vitest.js
+++ b/tests/settings-persistence.vitest.js
@@ -31,6 +31,28 @@ vi.mock('../js/status-helper.js', () => ({
 
 const localStorageMock = createLocalStorageMock();
 
+function getEventListener(element, eventName) {
+    const listener = element.addEventListener.mock.calls
+        .find(([registeredEventName]) => registeredEventName === eventName)?.[1];
+
+    expect(listener).toBeTypeOf('function');
+    return listener;
+}
+
+function configureNativeDialog(settings) {
+    const modal = settings.settingsModal;
+    modal.open = false;
+    modal.showModal = vi.fn(function showModal() {
+        this.open = true;
+    });
+    modal.close = vi.fn(function close() {
+        this.open = false;
+    });
+    modal.removeAttribute = vi.fn();
+
+    return modal;
+}
+
 Object.defineProperty(window, 'localStorage', {
     value: localStorageMock,
     writable: true
@@ -68,6 +90,13 @@ describe('Settings Persistence & Save Workflow', () => {
                 element.value = 'whisper';
             }
         });
+
+        const modal = document.getElementById(ID.SETTINGS_MODAL);
+        delete modal.showModal;
+        delete modal.close;
+        delete modal.open;
+        delete modal.removeAttribute;
+        delete document.getElementById(ID.SETTINGS_BUTTON).isConnected;
 
         eventBusEmitSpy = vi.spyOn(eventBus, 'emit');
 
@@ -245,6 +274,126 @@ describe('Settings Persistence & Save Workflow', () => {
             expect(eventBusEmitSpy).toHaveBeenCalledWith(APP_EVENTS.UI_SETTINGS_OPENED);
         });
 
+        test('uses native dialog semantics and focuses the first invalid active credential field', () => {
+            const modal = configureNativeDialog(settings);
+            settings.settingsButton.isConnected = true;
+            settings.whisperUriInput.value = 'https://whisper.openai.azure.com/transcribe';
+            settings.whisperKeyInput.value = '';
+
+            settings.openSettingsModal(settings.settingsButton);
+
+            expect(modal.showModal).toHaveBeenCalledOnce();
+            expect(settings.whisperKeyInput.focus).toHaveBeenCalledOnce();
+        });
+
+        test('focuses the modal model selector when active credentials are valid', () => {
+            configureNativeDialog(settings);
+            settings.whisperUriInput.value = 'https://whisper.openai.azure.com/transcribe';
+            settings.whisperKeyInput.value = generateMockApiKeyForValidation();
+
+            settings.openSettingsModal(settings.settingsButton);
+
+            expect(settings.settingsModelSelect.focus).toHaveBeenCalledOnce();
+        });
+
+        test('falls back to display behavior when native dialogs are unavailable without stranding focus', () => {
+            settings.whisperUriInput.value = 'https://whisper.openai.azure.com/transcribe';
+            settings.whisperKeyInput.value = generateMockApiKeyForValidation();
+            settings.settingsButton.isConnected = true;
+
+            settings.openSettingsModal(settings.settingsButton);
+            settings.closeSettingsModal();
+
+            expect(settings.settingsModal.style.display).toBe('none');
+            expect(settings.settingsModelSelect.focus).toHaveBeenCalledOnce();
+            expect(settings.settingsButton.focus).toHaveBeenCalledOnce();
+        });
+
+        test('makes the no-showModal fallback visually and accessibly modal while inerting background interaction', () => {
+            const background = document.createElement('main');
+            document.body.appendChild(background);
+            background.inert = false;
+            settings.settingsModal.removeAttribute = vi.fn();
+
+            try {
+                settings.openSettingsModal(settings.settingsButton);
+
+                expect(settings.settingsModal.classList.add).toHaveBeenCalledWith('modal--fallback-open');
+                expect(settings.settingsModal.setAttribute).toHaveBeenCalledWith('role', 'dialog');
+                expect(settings.settingsModal.setAttribute).toHaveBeenCalledWith('aria-modal', 'true');
+                expect(background.inert).toBe(true);
+                expect(background.getAttribute('aria-hidden')).toBe('true');
+
+                settings.closeSettingsModal();
+
+                expect(settings.settingsModal.classList.remove).toHaveBeenCalledWith('modal--fallback-open');
+                expect(settings.settingsModal.removeAttribute).toHaveBeenCalledWith('role');
+                expect(settings.settingsModal.removeAttribute).toHaveBeenCalledWith('aria-modal');
+                expect(background.inert).toBe(false);
+                expect(background.hasAttribute('aria-hidden')).toBe(false);
+            } finally {
+                background.remove();
+            }
+        });
+
+        test('cycles fallback Tab navigation within the modal without adding a native-dialog trap', () => {
+            const firstFocusable = settings.closeModalButton;
+            const lastFocusable = settings.saveSettingsButton;
+            settings.settingsModal.querySelectorAll.mockReturnValue([firstFocusable, lastFocusable]);
+            const forwardTab = { key: 'Tab', shiftKey: false, target: lastFocusable, preventDefault: vi.fn() };
+            const backwardTab = { key: 'Tab', shiftKey: true, target: firstFocusable, preventDefault: vi.fn() };
+
+            settings.openSettingsModal(settings.settingsButton);
+            settings._fallbackModalKeydownHandler(forwardTab);
+            settings._fallbackModalKeydownHandler(backwardTab);
+
+            expect(firstFocusable.focus).toHaveBeenCalledOnce();
+            expect(lastFocusable.focus).toHaveBeenCalledOnce();
+            expect(forwardTab.preventDefault).toHaveBeenCalledOnce();
+            expect(backwardTab.preventDefault).toHaveBeenCalledOnce();
+
+            settings.closeSettingsModal();
+            const modal = configureNativeDialog(settings);
+            settings.openSettingsModal(settings.settingsButton);
+            settings._fallbackModalKeydownHandler(forwardTab);
+
+            expect(modal.showModal).toHaveBeenCalledOnce();
+            expect(firstFocusable.focus).toHaveBeenCalledOnce();
+        });
+
+        test('does not restore focus after startup opens settings without a meaningful invoker', () => {
+            configureNativeDialog(settings);
+            settings.whisperUriInput.value = 'https://whisper.openai.azure.com/transcribe';
+            settings.whisperKeyInput.value = generateMockApiKeyForValidation();
+
+            settings.openSettingsModal();
+            settings.closeSettingsModal();
+
+            expect(settings.settingsButton.focus).not.toHaveBeenCalled();
+        });
+
+        test('does not return focus to an invoker removed before close', () => {
+            configureNativeDialog(settings);
+            settings.settingsButton.isConnected = true;
+
+            settings.openSettingsModal(settings.settingsButton);
+            settings.settingsButton.isConnected = false;
+            settings.closeSettingsModal();
+
+            expect(settings.settingsButton.focus).not.toHaveBeenCalled();
+        });
+
+        test('uses the settings button as the invoker for settings-button clicks', () => {
+            configureNativeDialog(settings);
+            settings.settingsButton.isConnected = true;
+            const settingsButtonListener = getEventListener(settings.settingsButton, 'click');
+
+            settingsButtonListener();
+            settings.closeSettingsModal();
+
+            expect(settings.settingsButton.focus).toHaveBeenCalledOnce();
+        });
+
         test('should discard an unsaved model draft when closed with the close button', () => {
             const modalModelSelect = settings.settingsModelSelect;
             const modalChangeListener = modalModelSelect.addEventListener.mock.calls
@@ -277,6 +426,79 @@ describe('Settings Persistence & Save Workflow', () => {
 
             expect(settings.modelSelect.value).toBe(MODEL_TYPES.WHISPER);
             expect(settings.getModelConfig().model).toBe(MODEL_TYPES.WHISPER);
+        });
+
+        test('routes close button, backdrop, and cancel through one discard and return-focus cleanup', () => {
+            const modal = configureNativeDialog(settings);
+            settings.settingsButton.isConnected = true;
+            const modalModelSelect = settings.settingsModelSelect;
+            const modalChangeListener = getEventListener(modalModelSelect, 'change');
+            const closeButtonListener = getEventListener(settings.closeModalButton, 'click');
+            const backdropListener = getEventListener(modal, 'click');
+            const cancelListener = getEventListener(modal, 'cancel');
+            const cancelEvent = { preventDefault: vi.fn() };
+
+            [
+                () => closeButtonListener(),
+                () => backdropListener({ target: modal }),
+                () => cancelListener(cancelEvent)
+            ].forEach(close => {
+                settings.modelSelect.value = MODEL_TYPES.WHISPER;
+                settings.openSettingsModal(settings.settingsButton);
+                modalModelSelect.value = MODEL_TYPES.MAI_TRANSCRIBE_1_5;
+                modalChangeListener({ target: modalModelSelect });
+
+                close();
+
+                expect(settings.modelSelect.value).toBe(MODEL_TYPES.WHISPER);
+                expect(settings.getModelConfig().model).toBe(MODEL_TYPES.WHISPER);
+            });
+
+            expect(modal.close).toHaveBeenCalledTimes(3);
+            expect(settings.settingsButton.focus).toHaveBeenCalledTimes(3);
+            expect(cancelEvent.preventDefault).toHaveBeenCalledOnce();
+        });
+
+        test('keeps Escape owned by the open dialog rather than also unpinning the sidebar', () => {
+            const modal = configureNativeDialog(settings);
+            settings.sidePanel = {
+                classList: { contains: vi.fn(() => true) }
+            };
+            const unpinSidebarSpy = vi.spyOn(settings, 'unpinSidebar');
+            const cancelListener = getEventListener(modal, 'cancel');
+
+            settings.openSettingsModal(settings.settingsButton);
+            settings._panelEscHandler({ key: 'Escape' });
+            cancelListener({ preventDefault: vi.fn() });
+
+            expect(unpinSidebarSpy).not.toHaveBeenCalled();
+            expect(modal.close).toHaveBeenCalledOnce();
+        });
+
+        test('does not add modal handlers during repeated open and close cycles', () => {
+            const modal = configureNativeDialog(settings);
+            const initialHandlerCount = modal.addEventListener.mock.calls.length;
+
+            settings.openSettingsModal(settings.settingsButton);
+            settings.closeSettingsModal();
+            settings.openSettingsModal(settings.settingsButton);
+            settings.closeSettingsModal();
+
+            expect(modal.showModal).toHaveBeenCalledTimes(2);
+            expect(modal.addEventListener.mock.calls).toHaveLength(initialHandlerCount);
+        });
+
+        test('uses the shared close cleanup after a successful save', () => {
+            const modal = configureNativeDialog(settings);
+            settings.settingsButton.isConnected = true;
+            settings.whisperUriInput.value = 'https://whisper.openai.azure.com/transcribe';
+            settings.whisperKeyInput.value = generateMockApiKeyForValidation();
+
+            settings.openSettingsModal(settings.settingsButton);
+            settings.saveSettings();
+
+            expect(modal.close).toHaveBeenCalledOnce();
+            expect(settings.settingsButton.focus).toHaveBeenCalledOnce();
         });
 
         test('should restore the active model as the draft when reopened', () => {


### PR DESCRIPTION
## Summary
- replace the settings overlay with a native dialog while preserving an accessible fallback
- contain keyboard focus, own Escape handling, discard drafts consistently, and restore focus safely
- add focused regression coverage for native and fallback modal behavior

## Verification
- 394 Vitest tests across 31 files
- 94% statement coverage
- Playwright Chromium smoke passed
- lint, dependency checks, production dependency check, and size budget passed
- independent closeout review passed after one revision round

Implements Plan 025.