### PR TITLE
Deduplicate microphone permission listener lifecycle

### DIFF
--- a/js/audio-handler.js
+++ b/js/audio-handler.js
@@ -641,5 +641,6 @@ export class AudioHandler {
     destroy() {
         this._unsubscribers.forEach(unsub => unsub());
         this._unsubscribers = [];
+        this.permissionManager.destroy();
     }
 }

--- a/js/permission-manager.js
+++ b/js/permission-manager.js
@@ -12,6 +12,8 @@ import { errorHandler } from './error-handler.js';
 export class PermissionManager {
     constructor() {
         this.permissionStatus = null;
+        this.permissionStatusResult = null;
+        this.permissionStatusChangeHandler = this.handlePermissionStatusChange.bind(this);
         this.microphoneStream = null;
     }
     
@@ -67,12 +69,29 @@ export class PermissionManager {
             if ('permissions' in navigator) {
                 const result = await navigator.permissions.query({ name: 'microphone' });
                 this.permissionStatus = result.state;
-                
-                // Listen for permission changes
-                result.addEventListener('change', () => {
-                    this.permissionStatus = result.state;
-                    this.handlePermissionChange(result.state);
-                });
+
+                if (result !== this.permissionStatusResult) {
+                    if (this.permissionStatusResult) {
+                        if (typeof this.permissionStatusResult.removeEventListener !== 'function') {
+                            return result.state;
+                        }
+
+                        try {
+                            this.permissionStatusResult.removeEventListener(
+                                'change', this.permissionStatusChangeHandler
+                            );
+                        } catch {
+                            return result.state;
+                        }
+                    }
+
+                    if (typeof result.addEventListener === 'function') {
+                        result.addEventListener('change', this.permissionStatusChangeHandler);
+                        this.permissionStatusResult = result;
+                    } else {
+                        this.permissionStatusResult = null;
+                    }
+                }
                 
                 return result.state;
             }
@@ -83,6 +102,21 @@ export class PermissionManager {
         
         // Fallback: we don't know the status
         return null;
+    }
+
+    /**
+     * Updates the cached permission state after a Permissions API change event.
+     *
+     * @method handlePermissionStatusChange
+     * @param {Event} event - Permissions API change event
+     * @returns {void}
+     */
+    handlePermissionStatusChange(event) {
+        const status = event?.target || this.permissionStatusResult;
+        if (!status) return;
+
+        this.permissionStatus = status.state;
+        this.handlePermissionChange(status.state);
     }
     
     /**
@@ -298,6 +332,27 @@ export class PermissionManager {
             });
             this.microphoneStream = null;
         }
+    }
+
+    /**
+     * Removes the permission listener and stops the stream owned by this manager.
+     *
+     * @method destroy
+     * @returns {void}
+     */
+    destroy() {
+        if (this.permissionStatusResult) {
+            try {
+                this.permissionStatusResult.removeEventListener?.(
+                    'change', this.permissionStatusChangeHandler
+                );
+            } catch {
+                // Older Permissions API implementations may not support removal.
+            }
+            this.permissionStatusResult = null;
+        }
+
+        this.stopMicrophoneStream();
     }
     
     /**

--- a/plans/026-deduplicate-permission-status-listener.md
+++ b/plans/026-deduplicate-permission-status-listener.md
@@ -3,7 +3,7 @@
 > **Executor instructions**: Follow all steps and verifications. Stop on drift
 > or a STOP condition and touch only scoped files.
 >
-> **Drift check (run first)**: `git diff --stat 559124e..HEAD -- js/permission-manager.js js/audio-handler.js tests/permission-manager.vitest.js tests/audio-handler-integration.vitest.js`
+> **Drift check (run first)**: `git diff --stat 8d17198..HEAD -- js/permission-manager.js js/audio-handler.js tests/permission-manager.vitest.js tests/audio-handler-integration.vitest.js`
 
 ## Status
 
@@ -12,7 +12,7 @@
 - **Risk**: LOW
 - **Depends on**: Plan 021 (to avoid overlapping AudioHandler lifecycle edits)
 - **Category**: perf
-- **Planned at**: commit `559124e`, 2026-07-12
+- **Planned at**: refreshed at commit `8d17198`, 2026-07-13 (after Plans 021, 023, and 024)
 
 ## Why this matters
 

--- a/plans/README.md
+++ b/plans/README.md
@@ -51,7 +51,7 @@ and update your row when done.
 | 023 | Preserve the browser-selected recording container | P2 | M | 021 | DONE (implemented as `b2fb90b`, independently approved, and merged via PR #95 as `63a2c8b`, 2026-07-13) |
 | 024 | Enforce model-specific audio upload limits before network submission | P2 | M | 021 + 023 | DONE (implemented as `daabc17`, independently approved, and merged via PR #96 as `54f4376`, 2026-07-13) |
 | 025 | Make the settings modal keyboard and focus correct | P2 | M | 022 | DONE (implemented as `9d6d5a3`, independently approved after one revision round, and merged via PR #97 as `083ce95`, 2026-07-13) |
-| 026 | Subscribe to microphone permission changes exactly once | P2 | S | 021 | TODO |
+| 026 | Subscribe to microphone permission changes exactly once | P2 | S | 021 | IN PROGRESS (implemented as `fdf0ca6`, independently approved; awaiting merge) |
 | 027 | Normalize API lifecycle events and opt in to event history | P2 | S/M | 021 | TODO |
 | 028 | Provide one supported local-development command and runtime baseline | P2 | S/M | — | TODO |
 | 029 | Lint tests, Playwright scaffolding, and repository tooling | P2 | M | 028 | TODO |

--- a/tests/audio-handler-integration.vitest.js
+++ b/tests/audio-handler-integration.vitest.js
@@ -736,6 +736,15 @@ describe('AudioHandler Integration', () => {
       expect(eventBus.events.has(APP_EVENTS.API_CONFIG_MISSING)).toBe(false);
     });
 
+    it('should destroy its permission manager after unsubscribing from the event bus', () => {
+      const permissionManagerDestroySpy = vi.spyOn(audioHandler.permissionManager, 'destroy');
+
+      audioHandler.destroy();
+
+      expect(eventBus.events.has(APP_EVENTS.API_CONFIG_MISSING)).toBe(false);
+      expect(permissionManagerDestroySpy).toHaveBeenCalledTimes(1);
+    });
+
     it('should not throw if destroy() is called twice', () => {
       audioHandler.destroy();
       expect(() => audioHandler.destroy()).not.toThrow();

--- a/tests/permission-manager.vitest.js
+++ b/tests/permission-manager.vitest.js
@@ -47,6 +47,31 @@ const mockPermissions = {
 
 const mockMediaRecorder = vi.fn();
 
+const createTrackedPermissionStatus = (state = 'prompt', supportsRemoval = true) => {
+    const listeners = new Set();
+    const status = {
+        state,
+        addEventListener: vi.fn((event, listener) => {
+            if (event === 'change') {
+                listeners.add(listener);
+            }
+        }),
+        emitChange: () => {
+            listeners.forEach(listener => listener({ target: status }));
+        }
+    };
+
+    if (supportsRemoval) {
+        status.removeEventListener = vi.fn((event, listener) => {
+            if (event === 'change') {
+                listeners.delete(listener);
+            }
+        });
+    }
+
+    return status;
+};
+
 // Create mock stream and tracks
 const createMockStream = (active = true) => {
     const mockTrack = {
@@ -292,6 +317,72 @@ describe('PermissionManager', () => {
             );
             expect(eventBusEmitSpy).toHaveBeenCalledWith(APP_EVENTS.PERMISSION_DENIED);
         });
+
+        it('subscribes once when repeated queries return the same status object', async () => {
+            const status = createTrackedPermissionStatus();
+            const handlePermissionChangeSpy = vi.spyOn(permissionManager, 'handlePermissionChange');
+            mockPermissions.query.mockResolvedValue(status);
+
+            await permissionManager.getPermissionStatus();
+            await permissionManager.getPermissionStatus();
+            await permissionManager.getPermissionStatus();
+
+            expect(status.addEventListener).toHaveBeenCalledTimes(1);
+
+            eventBusEmitSpy.mockClear();
+            status.state = 'granted';
+            status.emitChange();
+
+            expect(handlePermissionChangeSpy).toHaveBeenCalledTimes(1);
+            expect(handlePermissionChangeSpy).toHaveBeenCalledWith('granted');
+            expect(eventBusEmitSpy.mock.calls).toEqual([
+                [APP_EVENTS.PERMISSION_STATUS_CHANGED, { state: 'granted' }],
+                [APP_EVENTS.PERMISSION_GRANTED]
+            ]);
+        });
+
+        it('replaces the subscription when a permission query returns a new status object', async () => {
+            const previousStatus = createTrackedPermissionStatus();
+            const currentStatus = createTrackedPermissionStatus();
+            mockPermissions.query
+                .mockResolvedValueOnce(previousStatus)
+                .mockResolvedValueOnce(currentStatus);
+
+            await permissionManager.getPermissionStatus();
+            await permissionManager.getPermissionStatus();
+
+            expect(previousStatus.removeEventListener).toHaveBeenCalledWith(
+                'change',
+                previousStatus.addEventListener.mock.calls[0][1]
+            );
+            expect(currentStatus.addEventListener).toHaveBeenCalledTimes(1);
+
+            eventBusEmitSpy.mockClear();
+            previousStatus.state = 'denied';
+            previousStatus.emitChange();
+            currentStatus.state = 'granted';
+            currentStatus.emitChange();
+
+            expect(eventBusEmitSpy.mock.calls).toEqual([
+                [APP_EVENTS.PERMISSION_STATUS_CHANGED, { state: 'granted' }],
+                [APP_EVENTS.PERMISSION_GRANTED]
+            ]);
+        });
+
+        it('does not add a replacement listener when the prior status cannot remove one', async () => {
+            const previousStatus = createTrackedPermissionStatus('prompt', false);
+            const currentStatus = createTrackedPermissionStatus('granted');
+            mockPermissions.query
+                .mockResolvedValueOnce(previousStatus)
+                .mockResolvedValueOnce(currentStatus);
+
+            await permissionManager.getPermissionStatus();
+            await permissionManager.getPermissionStatus();
+
+            expect(permissionManager.permissionStatus).toBe('granted');
+            expect(previousStatus.addEventListener).toHaveBeenCalledTimes(1);
+            expect(currentStatus.addEventListener).not.toHaveBeenCalled();
+        });
     });
     
     describe('Stream Management', () => {
@@ -326,6 +417,25 @@ describe('PermissionManager', () => {
             
             // Should detect inactive stream
             expect(permissionManager.hasActiveStream()).toBe(false);
+        });
+
+        it('destroys its permission listener and microphone stream idempotently', async () => {
+            const status = createTrackedPermissionStatus();
+            const stream = createMockStream();
+            mockPermissions.query.mockResolvedValue(status);
+            permissionManager.microphoneStream = stream;
+
+            await permissionManager.getPermissionStatus();
+            permissionManager.destroy();
+
+            expect(status.removeEventListener).toHaveBeenCalledWith(
+                'change',
+                status.addEventListener.mock.calls[0][1]
+            );
+            expect(stream.getTracks()[0].stop).toHaveBeenCalledTimes(1);
+            expect(permissionManager.microphoneStream).toBeNull();
+            expect(() => permissionManager.destroy()).not.toThrow();
+            expect(status.removeEventListener).toHaveBeenCalledTimes(1);
         });
     });
     


### PR DESCRIPTION
## Summary
- retain one stable microphone PermissionStatus subscription
- detach or safely retain the prior listener when status objects change
- add idempotent permission and stream cleanup through AudioHandler destruction
- cover repeated queries, replacement, unsupported removal, event emission, and teardown

## Verification
- 399 Vitest tests across 31 files
- 93.95% statement coverage
- Playwright Chromium smoke passed
- lint, dependency checks, production dependency check, and size budget passed
- independent focused rerun and full-diff review passed

Implements Plan 026.