### PR TITLE
Normalize API lifecycle event ownership

### DIFF
--- a/js/audio-handler.js
+++ b/js/audio-handler.js
@@ -25,7 +25,6 @@ import { errorHandler } from './error-handler.js';
  * @fires APP_EVENTS.RECORDING_RESUMED
  * @fires APP_EVENTS.RECORDING_CANCELLED
  * @fires APP_EVENTS.RECORDING_ERROR
- * @fires APP_EVENTS.API_REQUEST_START
  * @fires APP_EVENTS.UI_TRANSCRIPTION_READY
  */
 export class AudioHandler {
@@ -587,7 +586,6 @@ export class AudioHandler {
                 temporary: true
             });
 
-            eventBus.emit(APP_EVENTS.API_REQUEST_SUCCESS);
             return { success: true };
 
         } catch (error) {

--- a/js/event-bus.js
+++ b/js/event-bus.js
@@ -7,7 +7,7 @@ import { logger } from './logger.js';
 /**
  * EventBus - Central event management system for the application.
  * Provides a decoupled way for modules to communicate using publish-subscribe pattern.
- * Supports event prioritization, one-time listeners, and event history tracking.
+ * Supports event prioritization, one-time listeners, and opt-in event history tracking.
  * 
  * @class EventBus
  * @example
@@ -25,11 +25,12 @@ import { logger } from './logger.js';
 export class EventBus {
     /**
      * Creates a new EventBus instance.
-     * Initializes the events map, event history, and debug mode.
+     * Initializes the events map, disabled event history, and debug mode.
      */
     constructor() {
         this.events = new Map();
         this.eventHistory = [];
+        this.historyEnabled = false;
         this.debugMode = false;
     }
     
@@ -103,16 +104,17 @@ export class EventBus {
             eventLogger.debug(`Emitting event: ${eventName}`, data);
         }
         
-        // Record event in history
-        this.eventHistory.push({
-            eventName,
-            data,
-            timestamp: Date.now()
-        });
-        
-        // Keep only last 50 events in history
-        if (this.eventHistory.length > 50) {
-            this.eventHistory.shift();
+        if (this.historyEnabled) {
+            this.eventHistory.push({
+                eventName,
+                data,
+                timestamp: Date.now()
+            });
+
+            // Keep only last 50 events in history
+            if (this.eventHistory.length > 50) {
+                this.eventHistory.shift();
+            }
         }
         
         if (!this.events.has(eventName)) return;
@@ -160,6 +162,19 @@ export class EventBus {
      */
     getHistory() {
         return [...this.eventHistory];
+    }
+
+    /**
+     * Enable or disable diagnostic event history recording.
+     * Disabling history clears any payloads that were already retained.
+     *
+     * @param {boolean} enabled - Whether to retain emitted event payloads
+     */
+    setHistoryEnabled(enabled) {
+        this.historyEnabled = Boolean(enabled);
+        if (!this.historyEnabled) {
+            this.eventHistory = [];
+        }
     }
     
     /**

--- a/js/recording-state-machine.js
+++ b/js/recording-state-machine.js
@@ -210,11 +210,9 @@ export class RecordingStateMachine {
      * @async
      * @private
      * @method handleProcessingState
-     * @fires APP_EVENTS.API_REQUEST_START
      * @fires APP_EVENTS.UI_STATUS_UPDATE
      */
     async handleProcessingState() {
-        eventBus.emit(APP_EVENTS.API_REQUEST_START);
         eventBus.emit(APP_EVENTS.UI_STATUS_UPDATE, {
             message: MESSAGES.PROCESSING_AUDIO,
             type: 'info'

--- a/plans/027-normalize-event-lifecycle-ownership.md
+++ b/plans/027-normalize-event-lifecycle-ownership.md
@@ -3,7 +3,7 @@
 > **Executor instructions**: Follow all steps, preserve event names, and stop on
 > any contract mismatch. Update only the plan's index status.
 >
-> **Drift check (run first)**: `git diff --stat 559124e..HEAD -- js/event-bus.js js/api-client.js js/audio-handler.js js/recording-state-machine.js tests/event-bus.vitest.js tests/model-adapters.vitest.js tests/audio-handler-integration.vitest.js tests/recording-state-machine.vitest.js`
+> **Drift check (run first)**: `git diff --stat e646249..HEAD -- js/event-bus.js js/api-client.js js/audio-handler.js js/recording-state-machine.js tests/event-bus.vitest.js tests/model-adapters.vitest.js tests/audio-handler-integration.vitest.js tests/recording-state-machine.vitest.js`
 
 ## Status
 
@@ -12,7 +12,7 @@
 - **Risk**: LOW
 - **Depends on**: Plan 021
 - **Category**: tech-debt
-- **Planned at**: commit `559124e`, 2026-07-12
+- **Planned at**: refreshed at commit `e646249`, 2026-07-13 (after Plans 021, 023, 024, and 026)
 
 ## Why this matters
 
@@ -28,7 +28,7 @@ ambiguous contracts and unnecessary sensitive-object retention.
 - `RecordingStateMachine.handleProcessingState()` emits bare
   `API_REQUEST_START`; `AzureAPIClient.transcribe()` emits the structured start.
 - `AzureAPIClient` emits structured `API_REQUEST_SUCCESS`; `AudioHandler` emits
-  it again with `{}` at `js/audio-handler.js:439`.
+  it again with `{}` at `js/audio-handler.js:590`.
 - `spec/spec-design-api-client.md:148-155` already describes the structured API
   client payloads as the contract.
 - `EventBus.emit()` unconditionally pushes `{eventName,data,timestamp}` and caps

--- a/plans/README.md
+++ b/plans/README.md
@@ -52,7 +52,7 @@ and update your row when done.
 | 024 | Enforce model-specific audio upload limits before network submission | P2 | M | 021 + 023 | DONE (implemented as `daabc17`, independently approved, and merged via PR #96 as `54f4376`, 2026-07-13) |
 | 025 | Make the settings modal keyboard and focus correct | P2 | M | 022 | DONE (implemented as `9d6d5a3`, independently approved after one revision round, and merged via PR #97 as `083ce95`, 2026-07-13) |
 | 026 | Subscribe to microphone permission changes exactly once | P2 | S | 021 | DONE (implemented as `fdf0ca6`, independently approved, and merged via PR #98 as `c6b50f8`, 2026-07-13) |
-| 027 | Normalize API lifecycle events and opt in to event history | P2 | S/M | 021 | TODO |
+| 027 | Normalize API lifecycle events and opt in to event history | P2 | S/M | 021 | IN PROGRESS (implemented as `70a7507`, independently approved; awaiting merge) |
 | 028 | Provide one supported local-development command and runtime baseline | P2 | S/M | — | TODO |
 | 029 | Lint tests, Playwright scaffolding, and repository tooling | P2 | M | 028 | TODO |
 | 030 | Reconcile active model and state-machine documentation | P2 | S | 027 | TODO |

--- a/tests/audio-handler-integration.vitest.js
+++ b/tests/audio-handler-integration.vitest.js
@@ -51,12 +51,13 @@ const createAudioChunk = (size = 1024, type = 'audio/webm') => {
 };
 
 // Import modules before tests
-let AudioHandler, eventBus, APP_EVENTS, AUDIO_UPLOAD_LIMIT_ERROR_CODE, RECORDING_STATES;
+let AudioHandler, AzureAPIClient, eventBus, APP_EVENTS, AUDIO_UPLOAD_LIMIT_ERROR_CODE, RECORDING_STATES, MESSAGES;
 
 beforeAll(async () => {
   ({ eventBus, APP_EVENTS } = await import('../js/event-bus.js'));
-  ({ AUDIO_UPLOAD_LIMIT_ERROR_CODE, RECORDING_STATES } = await import('../js/constants.js'));
+  ({ AUDIO_UPLOAD_LIMIT_ERROR_CODE, RECORDING_STATES, MESSAGES } = await import('../js/constants.js'));
   ({ AudioHandler } = await import('../js/audio-handler.js'));
+  ({ AzureAPIClient } = await import('../js/api-client.js'));
 });
 
 describe('AudioHandler Integration', () => {
@@ -388,6 +389,39 @@ describe('AudioHandler Integration', () => {
   });
 
   describe('Transcription retry', () => {
+    it('emits one structured lifecycle for a successful transcription', async () => {
+      mockSettings.getModelConfig.mockReturnValue({
+        model: 'whisper',
+        apiKey: 'test-api-key',
+        uri: 'https://test.azure.com'
+      });
+      globalThis.fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        headers: { get: vi.fn().mockReturnValue('text/plain') },
+        text: vi.fn().mockResolvedValue('Test transcription result')
+      });
+      audioHandler.apiClient = new AzureAPIClient(mockSettings);
+      audioHandler.stateMachine.currentState = RECORDING_STATES.STOPPING;
+
+      await audioHandler.stateMachine.transitionTo(RECORDING_STATES.PROCESSING);
+      await expect(audioHandler.sendToAzureAPI(new Blob(['audio'], { type: 'audio/webm' })))
+        .resolves.toEqual({ success: true });
+
+      expect(eventBusEmitSpy.mock.calls.filter(
+        ([event]) => event === APP_EVENTS.API_REQUEST_START
+      )).toEqual([[APP_EVENTS.API_REQUEST_START, {
+        model: 'whisper',
+        message: MESSAGES.SENDING_TO_WHISPER
+      }]]);
+      expect(eventBusEmitSpy.mock.calls.filter(
+        ([event]) => event === APP_EVENTS.API_REQUEST_SUCCESS
+      )).toEqual([[APP_EVENTS.API_REQUEST_SUCCESS, {
+        model: 'whisper',
+        transcriptionLength: 'Test transcription result'.length
+      }]]);
+    });
+
     it('carries an upload-limit error code through sendToAzureAPI', async () => {
       const uploadLimitError = new Error('Azure Whisper accepts recordings up to 25 MB. Make a shorter recording and try again.');
       uploadLimitError.code = AUDIO_UPLOAD_LIMIT_ERROR_CODE;
@@ -477,6 +511,59 @@ describe('AudioHandler Integration', () => {
         APP_EVENTS.UI_TRANSCRIPTION_READY,
         { text: 'Recovered transcription' }
       );
+    });
+
+    it('emits one structured lifecycle for each user-initiated retry', async () => {
+      mockSettings.getModelConfig.mockReturnValue({
+        model: 'whisper',
+        apiKey: 'test-api-key',
+        uri: 'https://test.azure.com'
+      });
+      globalThis.fetch = vi.fn()
+        .mockResolvedValueOnce({
+          ok: false,
+          status: 400,
+          headers: { get: vi.fn().mockReturnValue(null) },
+          text: vi.fn().mockResolvedValue('Bad request')
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          status: 200,
+          headers: { get: vi.fn().mockReturnValue('text/plain') },
+          text: vi.fn().mockResolvedValue('Recovered transcription')
+        });
+      audioHandler.apiClient = new AzureAPIClient(mockSettings);
+      audioHandler.audioChunks = [new Uint8Array([1, 2, 3])];
+      audioHandler.stateMachine.currentState = RECORDING_STATES.PROCESSING;
+
+      await audioHandler.processAndSendAudio(mockStream);
+      await audioHandler.retryPendingTranscription();
+
+      expect(eventBusEmitSpy.mock.calls.filter(
+        ([event]) => event === APP_EVENTS.API_REQUEST_START
+      )).toEqual([
+        [APP_EVENTS.API_REQUEST_START, {
+          model: 'whisper',
+          message: MESSAGES.SENDING_TO_WHISPER
+        }],
+        [APP_EVENTS.API_REQUEST_START, {
+          model: 'whisper',
+          message: MESSAGES.SENDING_TO_WHISPER
+        }]
+      ]);
+      expect(eventBusEmitSpy.mock.calls.filter(
+        ([event]) => event === APP_EVENTS.API_REQUEST_ERROR
+      )).toEqual([[APP_EVENTS.API_REQUEST_ERROR, {
+        error: 'API responded with status: 400',
+        status: 400,
+        details: 'Bad request'
+      }]]);
+      expect(eventBusEmitSpy.mock.calls.filter(
+        ([event]) => event === APP_EVENTS.API_REQUEST_SUCCESS
+      )).toEqual([[APP_EVENTS.API_REQUEST_SUCCESS, {
+        model: 'whisper',
+        transcriptionLength: 'Recovered transcription'.length
+      }]]);
     });
 
     it('ignores retry clicks when there is no failed transcription payload', async () => {

--- a/tests/event-bus.vitest.js
+++ b/tests/event-bus.vitest.js
@@ -65,7 +65,20 @@ describe('EventBus direct behavior', () => {
     expect(order).toEqual(['first', 'second', 'third']);
   });
 
-  it('records history and caps it at 50 entries', () => {
+  it('delivers events without retaining payloads by default', () => {
+    const listener = vi.fn();
+    const payload = { stream: { id: 'live-stream' }, transcript: 'Sensitive transcript' };
+    bus.on('evt:ephemeral', listener);
+
+    bus.emit('evt:ephemeral', payload);
+
+    expect(listener).toHaveBeenCalledWith(payload);
+    expect(bus.getHistory()).toEqual([]);
+  });
+
+  it('records opt-in history and caps it at 50 entries', () => {
+    bus.setHistoryEnabled(true);
+
     for (let i = 0; i < 55; i += 1) {
       bus.emit('evt:history', { i });
     }
@@ -77,12 +90,23 @@ describe('EventBus direct behavior', () => {
   });
 
   it('returns history copy instead of mutable internal reference', () => {
+    bus.setHistoryEnabled(true);
     bus.emit('evt:copy', { hello: 'world' });
     const history = bus.getHistory();
 
     history.push({ eventName: 'mutated' });
 
     expect(bus.getHistory()).toHaveLength(1);
+  });
+
+  it('clears retained history when history recording is disabled', () => {
+    bus.setHistoryEnabled(true);
+    bus.emit('evt:history', { beforeDisable: true });
+
+    bus.setHistoryEnabled(false);
+    bus.emit('evt:history', { afterDisable: true });
+
+    expect(bus.getHistory()).toEqual([]);
   });
 
   it('clears a single event or all events', () => {

--- a/tests/model-adapters.vitest.js
+++ b/tests/model-adapters.vitest.js
@@ -239,9 +239,51 @@ describe('AzureAPIClient model adapter registry', () => {
 
         await expect(apiClient.transcribe(new Blob(['audio'], { type: 'audio/webm' }))).rejects.toThrow(MESSAGES.UNKNOWN_API_RESPONSE);
 
-        expect(eventBusEmitSpy).toHaveBeenCalledWith(APP_EVENTS.API_REQUEST_ERROR, {
+        const errorEvents = eventBusEmitSpy.mock.calls.filter(
+            ([event]) => event === APP_EVENTS.API_REQUEST_ERROR
+        );
+        expect(errorEvents).toEqual([[APP_EVENTS.API_REQUEST_ERROR, {
             error: MESSAGES.UNKNOWN_API_RESPONSE
-        });
+        }]]);
+    });
+
+    it('emits one structured lifecycle when a retryable request succeeds', async () => {
+        const settings = createSettings(MODEL_TYPES.WHISPER);
+        const apiClient = new AzureAPIClient(settings);
+        const onProgress = vi.fn();
+        apiClient._sleep = vi.fn().mockResolvedValue();
+        globalThis.fetch
+            .mockResolvedValueOnce({
+                ok: false,
+                status: 429,
+                headers: { get: vi.fn().mockReturnValue(null) },
+                text: vi.fn().mockResolvedValue('Too many requests')
+            })
+            .mockResolvedValueOnce({
+                ok: true,
+                status: 200,
+                headers: { get: vi.fn().mockReturnValue('text/plain') },
+                text: vi.fn().mockResolvedValue('Retried transcription')
+            });
+
+        await expect(apiClient.transcribe(new Blob(['audio'], { type: 'audio/webm' }), onProgress))
+            .resolves.toBe('Retried transcription');
+
+        expect(eventBusEmitSpy.mock.calls.filter(
+            ([event]) => event === APP_EVENTS.API_REQUEST_START
+        )).toEqual([[APP_EVENTS.API_REQUEST_START, {
+            model: MODEL_TYPES.WHISPER,
+            message: MESSAGES.SENDING_TO_WHISPER
+        }]]);
+        expect(eventBusEmitSpy.mock.calls.filter(
+            ([event]) => event === APP_EVENTS.API_REQUEST_SUCCESS
+        )).toEqual([[APP_EVENTS.API_REQUEST_SUCCESS, {
+            model: MODEL_TYPES.WHISPER,
+            transcriptionLength: 'Retried transcription'.length
+        }]]);
+        expect(eventBusEmitSpy.mock.calls.filter(
+            ([event]) => event === APP_EVENTS.API_REQUEST_ERROR
+        )).toEqual([]);
     });
 
     it('keeps the existing Whisper Translate request and parsed text behavior', async () => {

--- a/tests/recording-state-machine.vitest.js
+++ b/tests/recording-state-machine.vitest.js
@@ -135,13 +135,13 @@ describe('RecordingStateMachine direct behavior', () => {
     });
   });
 
-  it('emits expected events for stopping and processing handlers', async () => {
+  it('emits expected events for stopping and processing handlers without owning API lifecycle events', async () => {
     await sm.handleStoppingState();
     await sm.handleProcessingState();
 
     expect(emitSpy).toHaveBeenCalledWith(APP_EVENTS.RECORDING_STOPPED);
     expect(emitSpy).toHaveBeenCalledWith(APP_EVENTS.VISUALIZATION_STOP);
-    expect(emitSpy).toHaveBeenCalledWith(APP_EVENTS.API_REQUEST_START);
+    expect(emitSpy).not.toHaveBeenCalledWith(APP_EVENTS.API_REQUEST_START);
   });
 
   it('emits expected events for cancelling and error handlers', async () => {


### PR DESCRIPTION
## Summary
- make AzureAPIClient the sole owner of structured API lifecycle events
- remove duplicate bare start and empty success emissions from orchestration layers
- disable EventBus payload history by default with explicit opt-in and clearing
- add exact-once lifecycle, retry, and retention regression coverage

## Verification
- 404 Vitest tests across 31 files
- coverage thresholds passed
- Playwright Chromium smoke passed
- lint, dependency checks, production dependency check, size, retention scan, and diff review passed

Implements Plan 027.