### PR TITLE
Add supported local development server

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,21 +4,30 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## What this is
 
-A no-build, zero-runtime-dependency browser app (vanilla ES modules) that records speech and transcribes it via the user's own Azure Speech Services account, wrapped in a "Dynamic Island" morphing UI. There is no bundler and no dev server script — serve the folder with any static file server (ES modules won't load from `file://`).
+A no-build, zero-runtime-dependency browser app (vanilla ES modules) that records speech and transcribes it via the user's own Azure Speech Services account, wrapped in a "Dynamic Island" morphing UI. There is no bundler; run `npm start` to serve the folder locally because ES modules will not load from `file://`.
 
 ## Commands
 
 ```bash
+npm start                                   # local app server (http://127.0.0.1:4173; Ctrl+C to stop)
 npm test                                    # full suite (Vitest)
 npx vitest run tests/<name>.vitest.js       # single test file
 npm run test:watch                          # watch mode
 npm run test:coverage                       # enforces thresholds: stmts 85 / branches 80 / funcs 70 / lines 85
+npm run test:browser                        # Playwright browser tests (headless)
+npm run test:browser:headed                 # headed Playwright tests (requires a GUI)
 npm run lint                                # ESLint (js/**/*.js)
 npm run lint:fix
 npm run deps:check                          # knip — unused files/deps/exports
 npm run deps:check:prod                     # knip production check (guards the zero-runtime-deps rule)
 npm run size                                # size-limit budget (js/*.js ≤ 100 kB)
 ```
+
+`npm start` uses Node built-ins only and defaults to the loopback URL shown
+above. Debug and info logging is enabled on localhost; append `?debug` to the
+URL to force it explicitly. Stop `npm start` before `npm run test:browser`:
+browser tests launch their own test-only static server and API stub on the test
+ports.
 
 Husky runs **lint** on pre-commit and **coverage + deps:check:prod** on pre-push, so a failing threshold or a new runtime dependency blocks the push.
 

--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ encoding a long clip never freezes the UI.
 ### Prerequisites
 
 - A modern browser (Chrome, Firefox, Edge, Safari)
+- Node.js 22 or newer (CI runs Node 24)
 - An Azure account with **Speech Services** enabled
 - Your Azure target URI and API key
 
@@ -86,8 +87,26 @@ encoding a long clip never freezes the UI.
 
 ## Development
 
+### Install
+
 ```bash
 npm install
+```
+
+### Run locally
+
+```bash
+npm start
+```
+
+Open the printed loopback URL (by default, http://127.0.0.1:4173/) in a
+browser. Stop the server with Ctrl+C. Debug and info logging is enabled on
+localhost; add `?debug` to the URL when you need to enable it explicitly (for
+example, http://127.0.0.1:4173/?debug).
+
+### Test
+
+```bash
 npm test               # run the test suite (Vitest)
 npm run test:watch     # watch mode
 npm run test:coverage  # run with coverage (enforces thresholds)
@@ -96,6 +115,16 @@ npm run lint:fix       # ESLint with --fix
 npm run deps:check     # knip — unused files / deps / exports
 npm run size           # size-limit budget check
 ```
+
+### Browser tests
+
+```bash
+npm run test:browser         # Playwright, headless by default
+npm run test:browser:headed  # requires a GUI
+```
+
+Stop `npm start` before running browser tests: Playwright launches its own
+test-only static server and local API stub on the same test ports.
 
 Coverage thresholds (statements 85 / branches 80 / functions 70 / lines 85) are
 enforced from `vitest.config.js`. Husky runs **lint** on pre-commit and

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
         "vitest": "^3.2.4"
       },
       "engines": {
-        "node": ">=20"
+        "node": ">=22"
       }
     },
     "node_modules/@ampproject/remapping": {

--- a/package.json
+++ b/package.json
@@ -6,9 +6,10 @@
   "description": "A no-build browser app that turns speech into text with Azure Speech Services, wrapped in an interaction-led Dynamic Island UI.",
   "type": "module",
   "engines": {
-    "node": ">=20"
+    "node": ">=22"
   },
   "scripts": {
+    "start": "node scripts/static-server.mjs",
     "test": "vitest run",
     "test:watch": "vitest --watch",
     "test:coverage": "vitest run --coverage",

--- a/plans/028-add-local-development-command.md
+++ b/plans/028-add-local-development-command.md
@@ -4,7 +4,7 @@
 > developer tool, not production application architecture. Stop if it requires
 > a runtime dependency or browser-test API behavior.
 >
-> **Drift check (run first)**: `git diff --stat 559124e..HEAD -- package.json package-lock.json README.md CLAUDE.md .github/workflows/ci.yml tests/browser/static-server.mjs`
+> **Drift check (run first)**: `git diff --stat f9e36fe..HEAD -- package.json package-lock.json README.md CLAUDE.md .github/workflows/ci.yml tests/browser/static-server.mjs`
 
 ## Status
 
@@ -13,7 +13,7 @@
 - **Risk**: LOW
 - **Depends on**: none
 - **Category**: dx
-- **Planned at**: commit `559124e`, 2026-07-12
+- **Planned at**: refreshed at commit `f9e36fe`, 2026-07-13
 
 ## Why this matters
 

--- a/plans/README.md
+++ b/plans/README.md
@@ -53,7 +53,7 @@ and update your row when done.
 | 025 | Make the settings modal keyboard and focus correct | P2 | M | 022 | DONE (implemented as `9d6d5a3`, independently approved after one revision round, and merged via PR #97 as `083ce95`, 2026-07-13) |
 | 026 | Subscribe to microphone permission changes exactly once | P2 | S | 021 | DONE (implemented as `fdf0ca6`, independently approved, and merged via PR #98 as `c6b50f8`, 2026-07-13) |
 | 027 | Normalize API lifecycle events and opt in to event history | P2 | S/M | 021 | DONE (implemented as `70a7507`, independently approved, and merged via PR #99 as `4c0a5d7`, 2026-07-13) |
-| 028 | Provide one supported local-development command and runtime baseline | P2 | S/M | — | TODO |
+| 028 | Provide one supported local-development command and runtime baseline | P2 | S/M | — | IN PROGRESS (implemented as `07ee6c5`, independently approved after two review rounds; awaiting merge) |
 | 029 | Lint tests, Playwright scaffolding, and repository tooling | P2 | M | 028 | TODO |
 | 030 | Reconcile active model and state-machine documentation | P2 | S | 027 | TODO |
 

--- a/scripts/static-server.mjs
+++ b/scripts/static-server.mjs
@@ -1,0 +1,223 @@
+/**
+ * @fileoverview Local static server for developing the browser application.
+ */
+
+import { createReadStream } from 'node:fs';
+import { stat } from 'node:fs/promises';
+import { createServer } from 'node:http';
+import { isIP } from 'node:net';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const defaultHost = '127.0.0.1';
+const defaultPort = 4173;
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const mimeTypes = {
+    '.css': 'text/css; charset=utf-8',
+    '.gif': 'image/gif',
+    '.html': 'text/html; charset=utf-8',
+    '.ico': 'image/x-icon',
+    '.jpeg': 'image/jpeg',
+    '.jpg': 'image/jpeg',
+    '.js': 'text/javascript; charset=utf-8',
+    '.json': 'application/json; charset=utf-8',
+    '.mjs': 'text/javascript; charset=utf-8',
+    '.mp3': 'audio/mpeg',
+    '.png': 'image/png',
+    '.svg': 'image/svg+xml',
+    '.wav': 'audio/wav',
+    '.webm': 'audio/webm',
+    '.woff': 'font/woff',
+    '.woff2': 'font/woff2'
+};
+
+const host = validatedHost(process.env.HOST);
+const port = validatedPort(process.env.PORT);
+const acceptedHostHeaders = acceptedHostHeadersFor(host, port);
+
+function validatedHost(value) {
+    if (value === undefined) {
+        return defaultHost;
+    }
+
+    if (value === 'localhost' || value === '::1'
+        || (isIP(value) === 4 && value.startsWith('127.'))) {
+        return value;
+    }
+
+    throw new Error('HOST must be localhost, ::1, or a 127.0.0.0/8 address.');
+}
+
+function validatedPort(value) {
+    if (value === undefined) {
+        return defaultPort;
+    }
+
+    if (!/^\d+$/.test(value)) {
+        throw new Error('PORT must be an integer between 1 and 65535.');
+    }
+
+    const parsedPort = Number(value);
+    if (!Number.isSafeInteger(parsedPort) || parsedPort < 1 || parsedPort > 65535) {
+        throw new Error('PORT must be an integer between 1 and 65535.');
+    }
+
+    return parsedPort;
+}
+
+function displayHost(hostname) {
+    return isIP(hostname) === 6 ? `[${hostname}]` : hostname;
+}
+
+function hostHeader(hostname, listenPort) {
+    return `${displayHost(hostname)}:${listenPort}`;
+}
+
+function acceptedHostHeadersFor(hostname, listenPort) {
+    const hostnameOnly = displayHost(hostname).toLowerCase();
+    const acceptedHeaders = new Set([`${hostnameOnly}:${listenPort}`]);
+    if (listenPort === 80) {
+        acceptedHeaders.add(hostnameOnly);
+    }
+
+    return acceptedHeaders;
+}
+
+function hasExpectedHost(request) {
+    const requestHost = request.headers.host?.toLowerCase();
+    return requestHost !== undefined && acceptedHostHeaders.has(requestHost);
+}
+
+function requestPathname(requestUrl) {
+    const queryStart = requestUrl.search(/[?#]/);
+    return queryStart === -1 ? requestUrl : requestUrl.slice(0, queryStart);
+}
+
+function filePathFor(pathname) {
+    try {
+        const decodedPath = decodeURIComponent(pathname === '/' ? '/index.html' : pathname)
+            .replaceAll('\\', '/');
+        if (decodedPath.split('/').some(segment => segment.startsWith('.'))) {
+            return null;
+        }
+
+        const filePath = path.resolve(repoRoot, `.${decodedPath}`);
+        const relativePath = path.relative(repoRoot, filePath);
+
+        if (relativePath === '' || relativePath === '..'
+            || relativePath.startsWith(`..${path.sep}`) || path.isAbsolute(relativePath)) {
+            return null;
+        }
+
+        return filePath;
+    } catch {
+        return null;
+    }
+}
+
+function sendNotFound(response) {
+    response.writeHead(404, {
+        'Cache-Control': 'no-store',
+        'Content-Type': 'text/plain; charset=utf-8'
+    });
+    response.end('Not found');
+}
+
+async function serveFile(request, response) {
+    if (!hasExpectedHost(request)) {
+        sendNotFound(response);
+        return;
+    }
+
+    if (request.method !== 'GET' && request.method !== 'HEAD') {
+        sendNotFound(response);
+        return;
+    }
+
+    const pathname = requestPathname(request.url ?? '/');
+    if (!pathname.startsWith('/')) {
+        sendNotFound(response);
+        return;
+    }
+
+    const filePath = filePathFor(pathname);
+    if (!filePath) {
+        sendNotFound(response);
+        return;
+    }
+
+    try {
+        const fileStats = await stat(filePath);
+        if (!fileStats.isFile()) {
+            sendNotFound(response);
+            return;
+        }
+
+        const headers = {
+            'Cache-Control': 'no-store',
+            'Content-Length': fileStats.size,
+            'Content-Type': mimeTypes[path.extname(filePath).toLowerCase()] ?? 'application/octet-stream'
+        };
+
+        if (request.method === 'HEAD') {
+            response.writeHead(200, headers);
+            response.end();
+            return;
+        }
+
+        const fileStream = createReadStream(filePath);
+        let responseStarted = false;
+        fileStream.once('error', () => {
+            if (responseStarted) {
+                response.destroy();
+                return;
+            }
+
+            sendNotFound(response);
+        });
+        fileStream.once('open', () => {
+            responseStarted = true;
+            response.writeHead(200, headers);
+            fileStream.pipe(response);
+        });
+    } catch {
+        sendNotFound(response);
+    }
+}
+
+const server = createServer((request, response) => {
+    void serveFile(request, response);
+});
+
+server.once('error', error => {
+    console.error(`Unable to start local server: ${error.message}`);
+    process.exitCode = 1;
+});
+
+server.listen(port, host, () => {
+    console.log(`Local app available at http://${hostHeader(host, port)}/`);
+    console.log('Press Ctrl+C to stop.');
+});
+
+let shuttingDown = false;
+function shutdown(signal) {
+    if (shuttingDown) {
+        return;
+    }
+
+    shuttingDown = true;
+    console.log(`Received ${signal}; shutting down local server.`);
+    server.close(error => {
+        if (error) {
+            console.error(`Unable to stop local server: ${error.message}`);
+            process.exitCode = 1;
+            return;
+        }
+
+        console.log('Local server stopped.');
+    });
+    server.closeIdleConnections();
+}
+
+process.on('SIGINT', () => shutdown('SIGINT'));
+process.on('SIGTERM', () => shutdown('SIGTERM'));


### PR DESCRIPTION
## Summary
- add a zero-runtime-dependency npm start server for the real static app
- validate loopback host/port, Host headers, methods, traversal and hidden paths
- handle file churn and graceful shutdown safely
- raise the Node floor to 22 and document local running, debug logging, and browser-test behavior

## Verification
- root/module/CSS MIME, 404, traversal, hidden-path, Host-header, env override, and shutdown probes passed
- 404 Vitest tests, coverage, and Playwright Chromium smoke passed
- lint, dependency checks, zero production dependencies, size, lockfile audit, and clean final review passed
- two review rounds addressed source disclosure, stream errors, and DNS-rebinding defenses

Implements Plan 028.