### PR TITLE
Lint tests and repository tooling

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,56 +1,79 @@
-// eslint.config.js  —  ESLint 9 “flat” configuration
-import js from "@eslint/js";                    // recommended rules
+import js from '@eslint/js';
+import globals from 'globals';
+import unusedImports from 'eslint-plugin-unused-imports';
 
-import unusedImports from "eslint-plugin-unused-imports";
+const projectRules = {
+    'unused-imports/no-unused-imports': 'error',
+    'no-unused-vars': ['error', { argsIgnorePattern: '^_' }]
+};
 
 export default [
-
-  // 1) Glob‑style ignores (replaces .eslintignore)
-  {
-    ignores: ["node_modules/**", "coverage/**", "docs/**", "metrics/**"]
-  },
-
-  // 2) Base rules that match “eslint:recommended”
-  js.configs.recommended,
-
-  // 3) Project‑specific rules
-  {
-    files: ["**/*.js"],
-    plugins: {
-      "unused-imports": unusedImports
+    {
+        ignores: [
+            'node_modules/**',
+            'coverage/**',
+            'docs/**',
+            'metrics/**',
+            'playwright-report/**',
+            'test-results/**'
+        ]
     },
-    languageOptions: {
-      ecmaVersion: "latest",
-      sourceType: "module",
-      globals: { 
-        // Browser globals
-        window: "readonly", 
-        document: "readonly",
-        console: "readonly",
-        navigator: "readonly",
-        localStorage: "readonly",
-        setTimeout: "readonly",
-        clearTimeout: "readonly",
-        setInterval: "readonly",
-        clearInterval: "readonly",
-        requestAnimationFrame: "readonly",
-        cancelAnimationFrame: "readonly",
-        fetch: "readonly",
-        AbortController: "readonly",
-        AbortSignal: "readonly",
-        FormData: "readonly",
-        Blob: "readonly",
-        URL: "readonly",
-        URLSearchParams: "readonly",
-        MediaRecorder: "readonly",
-        OfflineAudioContext: "readonly",
-        // Node.js globals (for development tools)
-        process: "readonly"
-      }
+    js.configs.recommended,
+    {
+        files: ['js/**/*.js'],
+        plugins: {
+            'unused-imports': unusedImports
+        },
+        languageOptions: {
+            ecmaVersion: 'latest',
+            sourceType: 'module',
+            globals: globals.browser
+        },
+        rules: projectRules
     },
-    rules: {
-      "unused-imports/no-unused-imports": "error",
-      "no-unused-vars": ["error", { argsIgnorePattern: "^_" }]
+    {
+        files: [
+            'tests/**/*.vitest.js',
+            'tests/helpers/**/*.js',
+            'tests/vitest-setup.js'
+        ],
+        plugins: {
+            'unused-imports': unusedImports
+        },
+        languageOptions: {
+            ecmaVersion: 'latest',
+            sourceType: 'module',
+            globals: {
+                ...globals.browser,
+                ...globals.node,
+                ...globals.vitest
+            }
+        },
+        rules: projectRules
+    },
+    {
+        files: [
+            '*.config.js',
+            'tests/browser/**/*.{js,mjs}',
+            'tests/browser-live/**/*.js',
+            'scripts/**/*.mjs'
+        ],
+        plugins: {
+            'unused-imports': unusedImports
+        },
+        languageOptions: {
+            ecmaVersion: 'latest',
+            sourceType: 'module',
+            globals: globals.node
+        },
+        rules: projectRules
+    },
+    {
+        files: ['tests/browser/**/*.spec.js'],
+        languageOptions: {
+            globals: {
+                self: 'readonly'
+            }
+        }
     }
-  }
 ];

--- a/js/audio-converter.js
+++ b/js/audio-converter.js
@@ -8,8 +8,6 @@
  * thread when Workers are unavailable (older browsers, file://, etc.).
  */
 
-/* global Worker */
-
 import { encodeWav } from './wav-encoder.js';
 
 const TARGET_SAMPLE_RATE = 16000;

--- a/js/audio-converter.worker.js
+++ b/js/audio-converter.worker.js
@@ -10,8 +10,6 @@
  * posts { requestId, error }.
  */
 
-/* global self */
-
 import { encodeWav } from './wav-encoder.js';
 
 self.addEventListener('message', (event) => {

--- a/js/logger.js
+++ b/js/logger.js
@@ -38,8 +38,9 @@ const LOG_LEVEL_NAMES = {
  */
 function detectEnvironment() {
     // Check for common development indicators
-    if (typeof process !== 'undefined' && process.env && process.env.NODE_ENV) {
-        return process.env.NODE_ENV;
+    const nodeProcess = globalThis.process;
+    if (nodeProcess?.env?.NODE_ENV) {
+        return nodeProcess.env.NODE_ENV;
     }
     
     // Check for localhost or development domains

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "@vitest/coverage-v8": "^3.2.4",
         "eslint": "^9.30.1",
         "eslint-plugin-unused-imports": "^4.1.4",
+        "globals": "^17.7.0",
         "happy-dom": "^20.10.2",
         "husky": "^9.1.7",
         "knip": "^5.61.3",
@@ -667,6 +668,19 @@
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@eslint/eslintrc/node_modules/globals": {
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-14.0.0.tgz",
+      "integrity": "sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/@eslint/js": {
@@ -2589,9 +2603,9 @@
       }
     },
     "node_modules/globals": {
-      "version": "14.0.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-14.0.0.tgz",
-      "integrity": "sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==",
+      "version": "17.7.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-17.7.0.tgz",
+      "integrity": "sha512-Czmyns5dUsq4seFBR/Kdydhmo8y9kC79hiSkPn0YcGtNnYWnrgt0vjrSjx9tspoDGWm2CMarffRuLjM4xUz8xg==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -17,8 +17,8 @@
     "test:browser:headed": "playwright test --headed",
     "test:browser:live": "playwright test --config playwright.live.config.js",
     "prepare": "husky",
-    "lint": "eslint \"js/**/*.js\"",
-    "lint:fix": "eslint --fix \"js/**/*.js\"",
+    "lint": "eslint \"js/**/*.js\" \"tests/**/*.{js,mjs}\" \"*.config.js\" \"scripts/**/*.mjs\"",
+    "lint:fix": "eslint --fix \"js/**/*.js\" \"tests/**/*.{js,mjs}\" \"*.config.js\" \"scripts/**/*.mjs\"",
     "deps:check": "knip",
     "deps:check:prod": "knip --production --dependencies",
     "size": "size-limit"
@@ -30,6 +30,7 @@
     "@vitest/coverage-v8": "^3.2.4",
     "eslint": "^9.30.1",
     "eslint-plugin-unused-imports": "^4.1.4",
+    "globals": "^17.7.0",
     "happy-dom": "^20.10.2",
     "husky": "^9.1.7",
     "knip": "^5.61.3",

--- a/plans/029-lint-tests-and-tooling.md
+++ b/plans/029-lint-tests-and-tooling.md
@@ -4,7 +4,7 @@
 > not silence the initial error set globally. Follow every gate and stop if the
 > change requires test-environment refactoring.
 >
-> **Drift check (run first)**: `git diff --stat 559124e..HEAD -- eslint.config.js package.json package-lock.json tests playwright.config.js playwright.live.config.js scripts`
+> **Drift check (run first)**: `git diff --stat 7c2f2c0..HEAD -- eslint.config.js package.json package-lock.json tests playwright.config.js playwright.live.config.js scripts`
 
 ## Status
 
@@ -13,7 +13,7 @@
 - **Risk**: LOW
 - **Depends on**: Plan 028
 - **Category**: dx
-- **Planned at**: commit `559124e`, 2026-07-12
+- **Planned at**: refreshed at commit `7c2f2c0`, 2026-07-13 (after Plan 028)
 
 ## Why this matters
 

--- a/plans/README.md
+++ b/plans/README.md
@@ -54,7 +54,7 @@ and update your row when done.
 | 026 | Subscribe to microphone permission changes exactly once | P2 | S | 021 | DONE (implemented as `fdf0ca6`, independently approved, and merged via PR #98 as `c6b50f8`, 2026-07-13) |
 | 027 | Normalize API lifecycle events and opt in to event history | P2 | S/M | 021 | DONE (implemented as `70a7507`, independently approved, and merged via PR #99 as `4c0a5d7`, 2026-07-13) |
 | 028 | Provide one supported local-development command and runtime baseline | P2 | S/M | — | DONE (implemented as `07ee6c5`, independently approved after two review rounds, and merged via PR #100 as `9206b02`, 2026-07-13) |
-| 029 | Lint tests, Playwright scaffolding, and repository tooling | P2 | M | 028 | TODO |
+| 029 | Lint tests, Playwright scaffolding, and repository tooling | P2 | M | 028 | IN PROGRESS (implemented as `e85b104`, independently approved; awaiting merge) |
 | 030 | Reconcile active model and state-machine documentation | P2 | S | 027 | TODO |
 
 Status values: TODO | IN PROGRESS | DONE | BLOCKED (with one-line reason) | REJECTED (with one-line rationale)

--- a/tests/audio-converter.vitest.js
+++ b/tests/audio-converter.vitest.js
@@ -31,7 +31,7 @@ const mockStart = vi.fn();
 
 const originalOfflineAudioContext = global.OfflineAudioContext;
 
-global.OfflineAudioContext = vi.fn().mockImplementation((channels, length, sampleRate) => ({
+global.OfflineAudioContext = vi.fn().mockImplementation((_channels, _length, _sampleRate) => ({
     decodeAudioData: mockDecodeAudioData,
     createBufferSource: () => ({
         buffer: null,

--- a/tests/recording-integration.vitest.js
+++ b/tests/recording-integration.vitest.js
@@ -107,7 +107,7 @@ class MockMediaRecorder {
     });
   }
 
-  start(timeslice) {
+  start(_timeslice) {
     this.state = 'recording';
     
     // Immediately simulate data being available
@@ -221,7 +221,7 @@ document.body.innerHTML = `
 `;
 
 // Import modules after setting up mocks
-let AudioHandler, RecordingStateMachine, PermissionManager, AzureAPIClient, eventBus, APP_EVENTS, RECORDING_STATES;
+let AudioHandler, RecordingStateMachine, PermissionManager, eventBus, APP_EVENTS, RECORDING_STATES;
 
 beforeAll(async () => {
   ({ eventBus, APP_EVENTS } = await import('../js/event-bus.js'));
@@ -229,7 +229,6 @@ beforeAll(async () => {
   ({ RecordingStateMachine } = await import('../js/recording-state-machine.js'));
   ({ PermissionManager } = await import('../js/permission-manager.js'));
   ({ AudioHandler } = await import('../js/audio-handler.js'));
-  ({ AzureAPIClient } = await import('../js/api-client.js'));
 });
 
 describe('Recording Integration', () => {
@@ -237,13 +236,10 @@ describe('Recording Integration', () => {
   let mockSettings;
   let mockApiClient;
   let eventBusEmitSpy;
-  let recordingStartedSpy;
-  let recordingStoppedSpy;
   let recordingPausedSpy;
   let recordingResumedSpy;
   let recordingCancelledSpy;
   let stateChangeSpy;
-  let apiRequestStartSpy;
   let transcriptionReadySpy;
   
   // Helper function for standardized async operation waiting
@@ -284,13 +280,10 @@ describe('Recording Integration', () => {
     eventBusEmitSpy = vi.spyOn(eventBus, 'emit');
     
     // For convenience, create aliases that filter specific events
-    recordingStartedSpy = eventBusEmitSpy;
-    recordingStoppedSpy = eventBusEmitSpy;
     recordingPausedSpy = eventBusEmitSpy;
     recordingResumedSpy = eventBusEmitSpy;
     recordingCancelledSpy = eventBusEmitSpy;
     stateChangeSpy = eventBusEmitSpy;
-    apiRequestStartSpy = eventBusEmitSpy;
     transcriptionReadySpy = eventBusEmitSpy;
   });
   

--- a/tests/settings-persistence.vitest.js
+++ b/tests/settings-persistence.vitest.js
@@ -7,7 +7,6 @@ import { expect, vi } from 'vitest';
 import { eventBus, APP_EVENTS } from '../js/event-bus.js';
 import { generateMockApiKeyForValidation } from './helpers/mock-api-keys.js';
 import { STORAGE_KEYS, MESSAGES, ID, MODEL_TYPES, RECORDING_ENVIRONMENTS } from '../js/constants.js';
-import { applyDomSpies } from './helpers/test-dom-vitest.js';
 import { createLocalStorageMock } from './helpers/mock-settings-dom.js';
 
 // Mock dependencies

--- a/tests/settings-unit.vitest.js
+++ b/tests/settings-unit.vitest.js
@@ -4,7 +4,6 @@
  */
 
 import { vi } from 'vitest';
-import { eventBus, APP_EVENTS } from '../js/event-bus.js';
 import { ID, MESSAGES, MODEL_TYPES, STORAGE_KEYS } from '../js/constants.js';
 import { applyDomSpies } from './helpers/test-dom-vitest.js';
 import { generateMockApiKey, generateMockApiKeyForValidation, generateInvalidMockApiKey } from './helpers/mock-api-keys.js';
@@ -214,7 +213,7 @@ describe('Settings Helper Methods - Isolated Unit Tests', () => {
                 throw new Error('Invalid URL');
             }
 
-            const httpsMatch = url.match(/^(https?):\/\/([^\/]+)(\/.*)?$/);
+            const httpsMatch = url.match(/^(https?):\/\/([^/]+)(\/.*)?$/);
             if (!httpsMatch) {
                 throw new Error('Invalid URL');
             }

--- a/tests/visualization-stop-expanded.vitest.js
+++ b/tests/visualization-stop-expanded.vitest.js
@@ -5,7 +5,6 @@
 
 import { vi } from 'vitest';
 import { eventBus, APP_EVENTS } from '../js/event-bus.js';
-import { COLORS } from '../js/constants.js';
 import { applyDomSpies, resetEventBus } from './helpers/test-dom-vitest.js';
 
 // Mock window.requestAnimationFrame and cancelAnimationFrame

--- a/tests/vitest-setup.js
+++ b/tests/vitest-setup.js
@@ -1,4 +1,4 @@
-import { afterEach, expect, vi, beforeAll } from 'vitest';
+import { afterEach, vi, beforeAll } from 'vitest';
 import { applyDomSpies as baseApplyDomSpies } from './helpers/test-dom-vitest.js';
 import { eventBus } from '../js/event-bus.js';
 import { logger } from '../js/logger.js';
@@ -145,7 +145,7 @@ if (!global.MediaRecorder) {
       this.onpause = null;
       this.onresume = null;
     }
-    start(timeslice) { 
+    start(_timeslice) {
       this.state = 'recording';
       if (this.onstart) this.onstart();
       setTimeout(() => {
@@ -180,7 +180,6 @@ if (!global.MediaRecorder) {
 
 // Advanced timer management and async utilities for complex flows
 const originalSetTimeout = global.setTimeout;
-const originalSetInterval = global.setInterval;
 
 // Export utilities for integration tests
 global.integrationTestUtils = {


### PR DESCRIPTION
## Summary
- broaden lint and lint:fix across production, Vitest/Happy DOM, Playwright/live scaffolding, configs, and local scripts
- scope browser, Node, and Vitest globals by execution environment using the official globals package
- repair genuine unused imports, variables, whitespace, and global references mechanically
- keep production modules free of Node and Vitest globals

## Verification
- all 67 intended JS/MJS files are covered by the lint surface
- 404 Vitest tests and 94.17% statement coverage passed
- Playwright Chromium smoke passed
- lint:fix/diff check, dependency checks, production dependency check, and size passed
- secret and scope audits passed

Implements Plan 029.